### PR TITLE
Make include guards consistent in libsensors

### DIFF
--- a/lib/conf.h
+++ b/lib/conf.h
@@ -31,4 +31,4 @@ extern FILE *sensors_yyin;
 /* This is defined in conf-parse.y */
 int sensors_yyparse(void);
 
-#endif /* LIB_SENSORS_CONF_H */
+#endif /* def LIB_SENSORS_CONF_H */

--- a/lib/general.h
+++ b/lib/general.h
@@ -18,8 +18,8 @@
     MA 02110-1301 USA.
 */
 
-#ifndef LIB_SENSORS_GENERAL
-#define LIB_SENSORS_GENERAL
+#ifndef LIB_SENSORS_GENERAL_H
+#define LIB_SENSORS_GENERAL_H
 
 /* These are general purpose functions. They allow you to use variable-
    length arrays, which are extended automatically. A distinction is
@@ -36,4 +36,4 @@ void sensors_add_array_els(const void *els, int nr_els, void *list,
 
 #define ARRAY_SIZE(arr)	(int)(sizeof(arr) / sizeof((arr)[0]))
 
-#endif /* LIB_SENSORS_GENERAL */
+#endif /* def LIB_SENSORS_GENERAL_H */

--- a/lib/scanner.h
+++ b/lib/scanner.h
@@ -24,5 +24,5 @@
 int sensors_scanner_init(FILE *input, const char *filename);
 void sensors_scanner_exit(void);
 
-#endif
+#endif /* def LIB_SENSORS_SCANNER_H */
 

--- a/lib/sensors.h
+++ b/lib/sensors.h
@@ -307,4 +307,4 @@ sensors_get_subfeature(const sensors_chip_name *name,
 }
 #endif /* __cplusplus */
 
-#endif /* def LIB_SENSORS_ERROR_H */
+#endif /* def LIB_SENSORS_SENSORS_H */

--- a/lib/sysfs.h
+++ b/lib/sysfs.h
@@ -19,8 +19,8 @@
     MA 02110-1301 USA.
 */
 
-#ifndef SENSORS_LIB_SYSFS_H
-#define SENSORS_LIB_SYSFS_H
+#ifndef LIB_SENSORS_SYSFS_H
+#define LIB_SENSORS_SYSFS_H
 
 extern char sensors_sysfs_mount[];
 
@@ -40,4 +40,4 @@ int sensors_write_sysfs_attr(const sensors_chip_name *name,
 			     const sensors_subfeature *subfeature,
 			     double value);
 
-#endif /* !SENSORS_LIB_SYSFS_H */
+#endif /* def LIB_SENSORS_SYSFS_H */


### PR DESCRIPTION
I noticed that the "#endif" in sensors.h had the wrong comment next to it, so I fixed it.  I checked the other headers in the lib folder and they didnt' have the same problem, but there was some inconsistency in the way include guards were named/commented, so I made them consistent.