### PR TITLE
Add lm-sensors detection for Nuvoton NCT6795D

### DIFF
--- a/prog/detect/sensors-detect
+++ b/prog/detect/sensors-detect
@@ -2183,6 +2183,13 @@ use constant FEAT_SMBUS	=> (1 << 7);
 		logdev => 0x0b,
 		features => FEAT_IN | FEAT_FAN | FEAT_TEMP,
 	}, {
+		name => "Nuvoton NCT6795D Super IO Sensors",
+		driver => "nct6775",
+		devid => 0xD350,
+		devid_mask => 0xFFF0,
+		logdev => 0x0b,
+		features => FEAT_IN | FEAT_FAN | FEAT_TEMP,
+	}, {
 		name => "Nuvoton NCT6102D/NCT6104D/NCT6106D Super IO Sensors",
 		driver => "nct6775",
 		devid => 0xC450,


### PR DESCRIPTION
This is the chip used on MSI (AM4 only?) motherboards.