### PR TITLE
Add 'configs' directory where sample configurations can be stored

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,7 @@ SVN HEAD
                   Add detection of Nuvoton NCT6795D
                   Add detection of DDR4 SPD
                   Add detection of ITE IT8987D
+  configs: Add sample configuration files.
 
 3.4.0 (2015-06-25)
   documentation: Update the note about libsensors license

--- a/README
+++ b/README
@@ -22,7 +22,16 @@ The directories within this package:
     sensor limits.
   - sensord: A daemon to watch sensor values and log problems. It
     includes RRD support.
+* configs
+  This directory contains sample configurations of various boards,
+  contributed by users of lm-sensors.
 
+  Older sample configurations can be found on an old lm-sensors wiki
+  archived here:
+  http://web.archive.org/web/20150901092438/http://www.lm-sensors.org:80/wiki/Configurations
+
+  Please contribute back a configuration of your board so other users with
+  the same hardware won't need to recreate it again and again.
 
 INSTALLING LM-SENSORS
 ---------------------

--- a/configs/Gigabyte/GA-M720-US3.conf
+++ b/configs/Gigabyte/GA-M720-US3.conf
@@ -1,0 +1,38 @@
+# input routing and scaling based on schematic of a similar MA770T-UD3 board
+
+chip "it8720-*"
+	label in0 "Vcore"
+
+	label in1 "VDDR"
+
+	label in2 "+3.3V"
+	set in2_min 3.3 * 0.95
+	set in2_max 3.3 * 1.05
+
+	# pin has probably ATX power good signal connected,
+	# but is not configured as such
+	ignore in3
+
+	label in4 "+12V"
+	compute in4 @ * (8.2 + 24.3) / 8.2, @ * 8.2 / (8.2 + 24.3)
+	set in4_min 12 * 0.95
+	set in4_max 12 * 1.05
+
+	# probably CPU current sense
+	ignore in5
+
+	ignore in6
+
+	compute in7 @ * (6.8 / 10 + 1), @ / (6.8 / 10 + 1)
+	set in7_min 5 * 0.95
+	set in7_max 5 * 1.05
+
+	ignore cpu0_vid
+
+	label fan1 "CPU FAN"
+	label fan2 "SYSTEM FAN 1"
+	label fan3 "SYSTEM FAN 2"
+	label fan4 "POWER FAN"
+
+	label temp1 "System Temp"
+	label temp3 "CPU Temp"

--- a/configs/MSI/MS-7302-K9A2GM-V.conf
+++ b/configs/MSI/MS-7302-K9A2GM-V.conf
@@ -1,0 +1,22 @@
+# input routing and scaling read from board schematic
+
+chip "f71882fg-*"
+	label in1 "CPU Vcore"
+	label in2 "+12V"
+	label in3 "+5V"
+	ignore in4
+	label in5 "+5VSB"
+	ignore in6
+
+	compute in2 (@ * 11.00), (@ / 11.00)
+	compute in3 ((@ * (47 + 10)) / 10), ((@ * 10) / (47 + 10))
+	compute in5 ((@ * (47 + 10)) / 10), ((@ * 10) / (47 + 10))
+
+	label fan1 "CPU Fan"
+	ignore fan2
+	label fan3 "SYS Fan"
+	ignore fan4
+
+	label temp1 "CPU Temperature"
+	ignore temp2
+	label temp3 "System Temperature"

--- a/configs/MSI/MS-7786-A55M-P33.conf
+++ b/configs/MSI/MS-7786-A55M-P33.conf
@@ -1,0 +1,20 @@
+# input routing and scaling read from board schematic
+
+chip "f71868a-*"
+	label in1 "Vcore"
+	label in2 "VDDR"
+	label in3 "+5V"
+	label in4 "+12V"
+	label in5 "Vcc1P1"
+	ignore in6
+
+	compute in3  @ * (200 + 47) / 47, @ * 47 / (200 + 47)
+	compute in4  @ * 11, @ / 11
+
+	label fan1 "CPU FAN"
+	label fan2 "SYS FAN1"
+	ignore fan3
+
+	label temp1 "System DDR Temp"
+	label temp2 "System Temp"
+	label temp3 "System SIO Temp"

--- a/etc/sensors.conf.default
+++ b/etc/sensors.conf.default
@@ -9,8 +9,11 @@
 # placed in custom configuration files located in /etc/sensors.d. This
 # approach makes further updates much easier.
 #
-# Such custom configuration files for specific mainboards can be found at
-# http://www.lm-sensors.org/wiki/Configurations
+# Such custom configuration files for specific mainboards can be found in
+# "configs" directory of lm-sensors package.
+#
+# Please contribute back a configuration of your board so other users with
+# the same hardware won't need to recreate it again and again.
 
 chip "lm78-*" "lm79-*" "lm80-*" "lm96080-*"
 

--- a/etc/sensors.conf.eg
+++ b/etc/sensors.conf.eg
@@ -6,6 +6,9 @@
 # and writing improper limits may have all sorts of weird effects,
 # from beeping to CPU throttling to instant reboot. If you want to
 # actually set the limits, remove the comment marks, then run "sensors -s".
+#
+# This is a legacy example file. In general, configurations for new boards
+# should be placed in custom configuration files located in /etc/sensors.d.
 
 chip "lm78-*" "lm79-*" "w83781d-*"
 


### PR DESCRIPTION
Most mainboards need a config file which describe which input of a
monitoring chip is connected to which voltage rail, what are scaling
factors of voltages that can't be measured directly by the chip, which
part of the board has each temperature sensor, which fan is connected to
which tachometer input of the chip, etc.

All these data need to be determined either from a board schematic (if
available) or by a trial-and-error method.

This can be a time consuming and error-prone work, fortunately, it needs to
be done just once per mainboard.
Currently, however, there is no standard mechanism to share such
configurations so multiple users of the same board don't basically waste
their time reinventing the wheel (or recreating the same configuration
again and again).

Previously, a wiki on an old lm-sensors site had a 'Configurations' page
where contributors could submit their configurations.

Since this site is down for two years now and it does not look like it is
coming back we need to find an another solution.

Let's use a standard 'contrib' directory in project repository, so we can
benefit from SCM infrastructure for managing these files.
Also, add a reminder in documentation asking people to contribute these
files for benefit of the whole community and configurations for 3
mainboards for a starter.

Signed-off-by: Maciej S. Szmigiero <mail@maciej.szmigiero.name>