### PR TITLE
Add Axiomtek CAPA800 board config file

### DIFF
--- a/configs/Axiomtek/CAPA800.conf
+++ b/configs/Axiomtek/CAPA800.conf
@@ -1,0 +1,25 @@
+# input routing and scaling mostly based on datasheet recommended setup,
+# differences were determined experimentally
+
+chip "w83627uhg-*"
+	label in0 "Vcore"
+
+	label in1 "+12V"
+	compute in1 @ * (10 + 150) / 10, @ * 10 / (10 + 150)
+	set in1_min 12 * 0.95
+	set in1_max 12 * 1.05
+
+	#label in4 "+2.5V"
+	#compute in4 @ * 2 / 1, @ * 1 / 2
+	# ^ probable, not in BIOS
+	ignore in4
+
+	label in5 "+3.3V"
+	compute in5 @ * 2 / 1, @ * 1 / 2
+	set in5_min 3.3 * 0.95
+	set in5_max 3.3 * 1.05
+
+	ignore fan1
+	label fan2 "CPUFAN"
+
+	ignore intrusion0


### PR DESCRIPTION
This PR adds board configuration file for Axiomtek CAPA800 Intel Atom
single board computer, which uses Winbond W83627UHG as its Super I/O.

Input routing and scaling on this board is mostly based on SIO datasheet
recommended setup, small differences were determined experimentally by
comparing sensors output with a BIOS screen.

Signed-off-by: Maciej S. Szmigiero <mail@maciej.szmigiero.name>
