### PR TITLE
fix wrong alg description, + intention of use

### DIFF
--- a/prog/pwm/fancontrol.8
+++ b/prog/pwm/fancontrol.8
@@ -7,11 +7,10 @@ fancontrol \- automated software based fan speed regulation to lower fan noise
 .I [configfile]
 
 .SH DESCRIPTION
-The purpose of \fBfancontrol\fP is to lower the noise level of the cooling fans
-by tolerating higher temperature, but only for periods width lower heat generation.
-For periods with high heat generation there will be no advantage in terms of noise,
-because at the end exceeding certain temperature levels in not tolerable and this
-requires certain cooling power.
+The purpose of \fBfancontrol\fP is to lower the noise level of the cooling fans.
+This is achieved by reducing fan speed and therefore accepting higher temperature
+while still controlling the temperature in order to exceed a limit. Therefore 
+the noise reduction is only effective for low thermal load periods.
 \fBfancontrol\fP is a shell script for use with lm_sensors. It reads its
 configuration from a file, then calculates fan speeds from temperatures and
 sets the corresponding PWM outputs to the computed values. 
@@ -124,7 +123,7 @@ increase.
 FCCHARCUR=hwmon0/device/pwm1=SQR
 .PP
 Quadratic curve may bring the sound level further down, with accepting higher temperature.
-It may  make sense in systems with predominatly very low thermal load.
+It may make sense in systems with predominatly very low thermal load.
 
 .SH SEE ALSO
 pwmconfig(8), sensors(1).

--- a/prog/pwm/fancontrol.8
+++ b/prog/pwm/fancontrol.8
@@ -9,7 +9,7 @@ fancontrol \- automated software based fan speed regulation
 .SH DESCRIPTION
 \fBfancontrol\fP is a shell script for use with lm_sensors. It reads its
 configuration from a file, then calculates fan speeds from temperatures and
-sets the corresponding PWM outputs to the computed values. 
+sets the corresponding PWM outputs to the computed values.
 
 .SH WARNING
 Please be careful when using the fan control features of your mainboard, in

--- a/prog/pwm/fancontrol.8
+++ b/prog/pwm/fancontrol.8
@@ -1,15 +1,20 @@
-.TH FANCONTROL 8 "September 2009" "lm-sensors 3"
+.TH FANCONTROL 8 "January 2018" "lm-sensors 3"
 .SH NAME
-fancontrol \- automated software based fan speed regulation
+fancontrol \- automated software based fan speed regulation to lower fan noise
 
 .SH SYNOPSIS
 .B fancontrol
 .I [configfile]
 
 .SH DESCRIPTION
+The purpose of \fBfancontrol\fP is to lower the noise level of the cooling fans
+by tolerating higher temperature, but only for periods width lower heat generation.
+For periods with high heat generation there will be no advantage in terms of noise,
+because at the end exceeding certain temperature levels in not tolerable and this
+requires certain cooling power.
 \fBfancontrol\fP is a shell script for use with lm_sensors. It reads its
 configuration from a file, then calculates fan speeds from temperatures and
-sets the corresponding PWM outputs to the computed values.
+sets the corresponding PWM outputs to the computed values. 
 
 .SH WARNING
 Please be careful when using the fan control features of your mainboard, in
@@ -109,12 +114,17 @@ loaded kernel drivers.
 .SH THE ALGORITHM
 
 \fBfancontrol\fP first reads its configuration, writes it to arrays and loops its
-main function.  This function gets the temperatures and fanspeeds from
+main function. This function gets the temperatures and fanspeeds from
 kernel driver files and calculates new speeds depending on temperature
 changes, but only if the temp is between MINTEMP and MAXTEMP. After that, the
-new values are written to the PWM outputs. Currently the speed increases
-quadratically with rising temperature. This way you won't hear your fans most
-of the time at best.
+new values are written to the PWM outputs. The fan speed increases
+linearly with rising temperature. Optional configuration enables quadratic
+increase. 
+.IP
+FCCHARCUR=hwmon0/device/pwm1=SQR
+.PP
+Quadratic curve may bring the sound level further down, with accepting higher temperature.
+It may  make sense in systems with predominatly very low thermal load.
 
 .SH SEE ALSO
 pwmconfig(8), sensors(1).

--- a/prog/pwm/fancontrol.8
+++ b/prog/pwm/fancontrol.8
@@ -1,16 +1,12 @@
 .TH FANCONTROL 8 "January 2018" "lm-sensors 3"
 .SH NAME
-fancontrol \- automated software based fan speed regulation to lower fan noise
+fancontrol \- automated software based fan speed regulation
 
 .SH SYNOPSIS
 .B fancontrol
 .I [configfile]
 
 .SH DESCRIPTION
-The purpose of \fBfancontrol\fP is to lower the noise level of the cooling fans.
-This is achieved by reducing fan speed and therefore accepting higher temperature
-while still controlling the temperature in order to exceed a limit. Therefore 
-the noise reduction is only effective for low thermal load periods.
 \fBfancontrol\fP is a shell script for use with lm_sensors. It reads its
 configuration from a file, then calculates fan speeds from temperatures and
 sets the corresponding PWM outputs to the computed values. 
@@ -122,8 +118,8 @@ increase.
 .IP
 FCCHARCUR=hwmon0/device/pwm1=SQR
 .PP
-Quadratic curve may bring the sound level further down, with accepting higher temperature.
-It may make sense in systems with predominatly very low thermal load.
+In systems with predominatly very low thermal load a quadratic curve results in lower
+fan speed with tradeoff of higher temperature.
 
 .SH SEE ALSO
 pwmconfig(8), sensors(1).

--- a/prog/pwm/fancontrol.8
+++ b/prog/pwm/fancontrol.8
@@ -116,9 +116,9 @@ new values are written to the PWM outputs. The fan speed increases
 linearly with rising temperature. Optional configuration enables quadratic
 increase. 
 .IP
-FCCHARCUR=hwmon0/device/pwm1=SQR
+FCSQUARE=hwmon0/device/pwm1=1
 .PP
-In systems with predominatly very low thermal load a quadratic curve results in lower
+In systems with predominantly very low thermal load a quadratic curve results in lower
 fan speed with tradeoff of higher temperature.
 
 .SH SEE ALSO


### PR DESCRIPTION
The description of the algorithm was wrong, this is fixed. it also reflects a new proposed variable in the config for turning the linear into a square transfer function. 
The chapter of description was only a functional description of what is does. An intention of use is in my opinion fundamentally important for users.