### PR TITLE
Bulk config recovery from archive.org

### DIFF
--- a/configs/ASRock/G41C-GS.conf
+++ b/configs/ASRock/G41C-GS.conf
@@ -1,0 +1,61 @@
+### Sensors configuration for ASRock G41C-GS motherboard
+### 2014-02-19, ianp <snailbox88-dev -at- yahoo -dot- com>
+### Thanks to Jean Delvare and Guenter Roeck
+### Comments are welcome.
+
+
+chip "w83627dhg-*"
+
+
+### Voltages
+
+   ignore in1          # Ignored until
+   ignore in4          # properly identified
+   label  in5  "+5V"
+   label  in6  "+12V"
+   ignore cpu0_vid     # Always at 0 in my case, so ignore it
+
+   ### Scale +5V and +12V.
+
+   compute  in5  @*3, @/3
+   compute  in6  @*(1+56/10), @/(1+56/10)
+
+   ### Set in0 according to CPU nominal voltage.
+
+   set in0_min   0.8500
+   set in0_max   1.3625
+   set in5_min   5 * 0.95
+   set in5_max   5 * 1.05
+   set in6_min  12 * 0.95
+   set in6_max  12 * 1.05
+
+### Temperatures
+
+   # temp3 is not identified
+
+   label  temp1  "N/B Temp"
+   label  temp2  "CPU Temp"
+
+   ### Set according to CPU and preference.
+
+   set temp1_max      60
+   set temp1_max_hyst 55
+   set temp2_max      60
+   set temp2_max_hyst 55
+
+### Fans
+
+   ### Ignore fan4 and fan5. There are
+   ### only 3 fan connectors on this board.
+
+   label  fan1  "POW Fan"
+   label  fan2  "CPU Fan"
+   label  fan3  "CHA Fan"
+   ignore fan4
+   ignore fan5
+
+   ### Set according to preference.
+
+   set fan1_min 0
+   set fan2_min 900
+   set fan3_min 0

--- a/configs/ASRock/K7VT2.conf
+++ b/configs/ASRock/K7VT2.conf
@@ -1,0 +1,62 @@
+# Configuration file contributed by Marcus Roeckrath
+
+# Sample configuration for ASRock K7VT2
+
+chip "w83697hf-*"
+
+   label in0 "VCore"
+   label in2 "+3.3V"
+   label in3 "+5V"
+   label in4 "+12V"
+   label in5 "-12V"
+   label in6 "-5V"
+   label in7 "V5SB"
+   label in8 "VBat"
+
+   compute in3 ((6.8/10)+1)*@ , @/((6.8/10)+1)
+   compute in4 ((28/10)+1)*@ , @/((28/10)+1)
+   # These are the compute lines for -12V and -5V from the
+   # sample config file sensors.conf.eg from the lm-sensors
+   # source archive.
+   # But these lines give positive values on the K7VT2 board.
+   # compute in5 (5.14 * @) - 14.91 , (@ + 14.91) / 5.14
+   # compute in6 (3.14 * @) - 7.71 , (@ + 7.71) / 3.14
+   # Therefor I use the compute lines for the positive
+   # voltages for the negative voltages also and added a "-"
+   # to get plausible negative values.
+   compute in5 -((28/10)+1)*@ , -@/((28/10)+1)
+   compute in6 -((6.8/10)+1)*@ , -@/((6.8/10)+1)
+   compute in7 ((6.8/10)+1)*@ , @/((6.8/10)+1)
+
+   set in0_min 1.5 * 0.95
+   set in0_max 1.65 * 1.05
+   set in2_min 3.3 * 0.95
+   set in2_max 3.3 * 1.05
+   set in3_min 5 * 0.95
+   set in3_max 5 * 1.05
+   set in4_min 12 * 0.95
+   set in4_max 12 * 1.05
+   set in5_min -12 * 0.9
+   set in5_max -12 * 1.1
+   set in6_min -5 * 0.9
+   set in6_max -5 * 1.1
+   set in7_min 5 * 0.95
+   set in7_max 5 * 1.05
+   set in8_min 3.0 * 0.8
+   set in8_max 3.0 * 1.2
+
+   label temp1 "System Temp"
+   label temp2 "CPU Temp"
+
+   set temp1_max 50
+   set temp1_max_hyst 45
+   set temp2_max 52
+   set temp2_max_hyst 47
+
+   label fan1 "CPU Fan"
+   label fan2 "Chassis Fan"
+
+   set fan1_div 4
+   set fan1_min 2000
+   set fan2_div 8
+   set fan2_min 1000

--- a/configs/ASRock/M2NF3-VSTA.conf
+++ b/configs/ASRock/M2NF3-VSTA.conf
@@ -1,0 +1,68 @@
+# lm_sensors configuration file for the ASRock M2NF3-VSTA motherboard
+# 2008-01-01, Hans de Goede <j.w.r.degoede@hhs.nl>
+# Comments welcome!
+
+# Winbond W83627EHF configuration for ASRock AM2NF3-VSTA
+chip "w83627ehf-*" "w83627dhg-*"
+
+    label in0 "VCore"
+    label in1 "VCore2"
+    label in2 "AVCC"
+    label in3 "3VCC"
+    label in6 "12V"
+    label in7 "VSB"
+    label in8 "VBAT"
+    label in9 "5V"
+
+# +12V and +5V use dividers recommended by datasheet
+    compute in6 @*(1+(56/10)),  @/(1+(56/10))
+    compute in9 @*(1+(22/10)),  @/(1+(22/10))
+
+# in4 and in5 are not used (they seem to be hooked up to 3.3v/2, but thats
+# already monitored)
+    ignore in4
+    ignore in5
+
+# we need to set all voltage limits (hurray for a well written BIOS)
+# Note you may need to adapt in0 and in1 depending on your CPU
+    set in0_min   0.9
+    set in0_max   1.5
+    set in1_min   0.9
+    set in1_max   1.5
+    set in2_min   3.3*0.95
+    set in2_max   3.3*1.05
+    set in3_min   3.3*0.95
+    set in3_max   3.3*1.05
+    set in6_min   12.0*0.9
+    set in6_max   12.0*1.1
+    set in7_min   3.3*0.95
+    set in7_max   3.3*1.05
+    set in8_min   3.0
+    set in8_max   3.3*1.05
+    set in9_min   5.0*0.95
+    set in9_max   5.0*1.05
+
+# Fans
+   label fan1      "Case Fan"
+   label fan2      "CPU Fan"
+   ignore fan3
+   ignore fan5
+# Fan minumums, disable fan1 min as a case fan isn't always connected,
+   set fan1_min    0
+#  set fan2_min    1700
+
+# Temperatures
+   label temp1     "Sys Temp"
+   label temp2     "CPU Temp"
+   label temp3     "CPU2 Temp"
+
+   set temp1_max       45
+   set temp1_max_hyst  40
+
+
+chip "k8temp-*"
+
+   label temp1 "Core0 Temp"
+   label temp2 "Core0 Temp"
+   label temp3 "Core1 Temp"
+   label temp4 "Core1 Temp"

--- a/configs/Abit/AA8-DuraMAX.conf
+++ b/configs/Abit/AA8-DuraMAX.conf
@@ -1,0 +1,68 @@
+# lm_sensors configuration file for the Abit AA8-DuraMAX motherboard
+# 2006-06-07, Hans de Goede <j.w.r.degoede@hhs.nl>
+# Comments welcome!
+
+
+chip "abituguru-*"
+
+
+### Voltages
+
+
+   label in0 "CPU Core Voltage"
+
+   label in1 "DDR Voltage"
+
+   label in2 "DDR VTT Voltage"
+
+   label in3 "ATX +12V"
+   compute in3 @*4.153 , @/4.153
+
+   label in4 "FSB VTT Voltage"
+
+   label in5 "NB Voltage"
+
+   label in6 "NB 2.5V Voltage"
+
+   label in7 "ATX +5V"
+   compute in7 @*1.788 , @/1.788
+
+   label in8 "ATX +3.3V"
+   compute in8 @*1.248 , @/1.248
+
+   label in9 "Standby Voltage (+5V)"
+   compute in9 @*1.788 , @/1.788 
+
+   ignore in10
+
+
+### Temperatures
+
+
+   label temp1 "CPU Temperature"
+
+   label temp2 "SYS Temperature"
+
+   label temp3 "PWM Temperature 1"
+
+   label temp4 "PWM Temperature 2"
+
+   ignore temp5
+   ignore temp6
+   ignore temp7
+
+
+### Fans
+
+
+   label fan1 "CPU FAN Speed"
+
+   label fan2 "NB FAN Speed"  
+
+   label fan3 "SYS FAN Speed"
+
+   label fan4 "AUX1 FAN Speed"
+
+   label fan5 "AUX2 FAN Speed"
+
+   ignore fan6

--- a/configs/Abit/AA8XE-Fatal1ty.conf
+++ b/configs/Abit/AA8XE-Fatal1ty.conf
@@ -1,0 +1,159 @@
+# lm_sensors configuration file for the Abit AA8XE-Fatal1ty motherboard
+
+# 2006-05-29, Author: Roger Lucas <roger@planbit.co.uk>
+
+# Please send comments to: <j.w.r.degoede@hhs.nl>
+
+
+
+chip "abituguru-*"
+
+
+
+### Voltages
+
+
+
+   label in0 "DDR VTT Voltage"
+
+   label in1 "CPU Core Voltage"
+
+   label in2 "Unknown Voltage" 
+
+   label in3 "DDR Voltage"
+
+   label in4 "NB Voltage" 
+
+   label in5 "Unknown Voltage"
+
+   label in6 "FSB VTT Voltage"
+
+   label in7 "NB 2.5V Voltage"
+
+   ignore in8
+
+   ignore in9
+
+   ignore in10
+
+   ignore in11
+
+
+
+### Temperatures
+
+
+
+   label temp1 "CPU Temperature"
+
+   label temp2 "SYS Temperature"
+
+   label temp3 "PWM#1 Temperature"
+
+   label temp4 "PWM#2 Temperature"
+
+   label temp5 "PWM#3 Temperature"
+
+   label temp6 "PWM#4 Temperature"
+
+   ignore temp7
+
+
+
+### Fans
+
+
+
+   label fan1 "CPU FAN Speed"
+
+   label fan2 "NB FAN Speed" 
+
+   label fan3 "SYS FAN Speed"
+
+   label fan4 "OTES1 FAN Speed"
+
+   label fan5 "OTES2 FAN Speed"
+
+   ignore fan6
+
+
+
+
+
+# The AA8XE Fatal1ty motherboard also contains a w83627hf which is used to
+
+# measure the ATX power supply rails. Below is the correct config for this
+
+
+
+chip "w83782d-*" "w83627hf-*"
+
+
+
+   ignore in0
+
+   ignore in1
+
+   label in2 "ATX +3.3V" 
+
+   label in3 "ATX +5V"   
+
+   label in4 "ATX +12V"  
+
+   ignore in5
+
+   ignore in6
+
+   label in7 "Standby Voltage (+5V)"
+
+   ignore in8
+
+
+
+   compute in3 ((6.8/10)+1)*@ ,  @/((6.8/10)+1)
+
+   compute in4 ((28/10)+1)*@  ,  @/((28/10)+1) 
+
+   compute in7 ((6.8/10)+1)*@ ,  @/((6.8/10)+1)
+
+
+
+   set in2_min 3.3 * 0.95
+
+   set in2_max 3.3 * 1.05
+
+   set in3_min 5.0 * 0.95
+
+   set in3_max 5.0 * 1.05
+
+   set in4_min 12 * 0.90 
+
+   set in4_max 12 * 1.10 
+
+   set in7_min 5 * 0.95  
+
+   set in7_max 5 * 1.05  
+
+
+
+   ignore fan1
+
+   ignore fan2
+
+   ignore fan3
+
+
+
+   ignore temp1
+
+   ignore temp2
+
+   ignore temp3
+
+
+
+   ignore vid
+
+   ignore alarms
+
+   ignore beep_enable

--- a/configs/Abit/AI7.conf
+++ b/configs/Abit/AI7.conf
@@ -1,0 +1,83 @@
+# This configuration is derived from the AN7 configuration and currently
+# untested, it should work fine though. Please send any success or failure
+# using this config to: Hans de Goede <j.w.r.degoede@…>.
+
+# Notice that this motherboard contains version 1 of the uGuru. This version
+# does not seem to properly support autodetecting the type of the bank1
+# sensors, nor does the autodetection of the number of fan sensors work
+# properly on this chip. 
+
+
+# lm_sensors configuration file for the Abit AI7 motherboard
+# 2006-06-24, Hans de Goede <j.w.r.degoede@hhs.nl>
+# Comments welcome!
+# Note it might be nessecaryto load the driver with the following params:
+# bank1_types=1,1,0,0,0,0,0,2,0,0,0,0,2,0,0,1 fan_sensors=5
+
+chip "abituguru-*"
+
+
+### Voltages
+
+
+   label in0 "CPU Core Voltage"
+
+   label in1 "DDR Voltage"
+
+   label in2 "DDR VTT Voltage"
+
+   label in3 "ATX +12V"
+   compute in3 @*4.153 , @/4.153
+
+   # I believe this is FSB VTT, in some Abit files its called GMCHVTT, below is the BIOS name
+   label in4 "AUXC Voltage"  
+
+   label in5 "NB Core Voltage"
+
+   label in6 "VCCVID Voltage"
+
+   label in7 "ATX +5V Voltage"
+   compute in7 @*1.788 , @/1.788
+
+   label in8 "ATX +3.3V Voltage"
+   compute in8 @*1.248 , @/1.248
+
+   label in9 "Standby Voltage (+5V)"   
+   compute in9 @*1.788 , @/1.788
+
+   label in10 "3VDUAL Voltage"
+   compute in10 @*1.248 , @/1.248
+
+
+### Temperatures
+
+
+   label temp1 "CPU Temperature"
+
+   label temp2 "System Temperature"
+
+   label temp3 "PWM Temperature"
+
+   ignore temp4
+
+   ignore temp5
+
+   ignore temp6
+
+   ignore temp7
+
+
+### Fans
+
+
+   label fan1 "CPU FAN Speed"
+
+   label fan2 "NB FAN Speed"  
+
+   label fan3 "SYS FAN Speed"
+
+   label fan4 "FAN4"
+
+   label fan5 "FAN5"
+
+   ignore fan6

--- a/configs/Abit/AN7.conf
+++ b/configs/Abit/AN7.conf
@@ -1,0 +1,79 @@
+# Notice that this was the first motherboard by Abit with the uGuru and thus
+# contains version 1 of the uGuru. This version does not seem to properly
+# support autodetecting the type of the bank1 sensors, nor does the
+# autodetection of the number of fan sensors work properly on this chip.
+
+
+# lm_sensors configuration file for the Abit AN7 motherboard
+# 2006-06-24, Hans de Goede <j.w.r.degoede@hhs.nl>
+# Comments welcome!
+# Note the driver MUST be loaded with the following params:
+# bank1_types=1,1,0,0,0,0,0,2,0,0,0,0,2,0,0,1 fan_sensors=5
+
+chip "abituguru-*"
+
+
+### Voltages
+
+
+   label in0 "CPU Core Voltage"
+
+   label in1 "DDR Voltage"
+
+   label in2 "DDR VTT Voltage"
+
+   label in3 "ATX +12V"
+   compute in3 @*4.153 , @/4.153
+
+   # I believe this is FSB VTT, in some Abit files its called GMCHVTT, below is the BIOS name
+   label in4 "AUXC Voltage"  
+
+   label in5 "NB Core Voltage"
+
+   label in6 "AGP VDDQ Voltage"
+
+   label in7 "ATX +5V Voltage"
+   compute in7 @*1.788 , @/1.788
+
+   label in8 "ATX +3.3V Voltage"
+   compute in8 @*1.248 , @/1.248
+
+   label in9 "Standby Voltage (+5V)"   
+   compute in9 @*1.788 , @/1.788
+
+   label in10 "3VDUAL Voltage"
+   compute in10 @*1.248 , @/1.248
+
+
+### Temperatures
+
+
+   label temp1 "CPU Temperature"
+
+   label temp2 "System Temperature"
+
+   label temp3 "PWM Temperature"
+
+   ignore temp4
+
+   ignore temp5
+
+   ignore temp6
+
+   ignore temp7
+
+
+### Fans
+
+
+   label fan1 "CPU FAN Speed"
+
+   label fan2 "NB FAN Speed"  
+
+   label fan3 "SYS FAN Speed"
+
+   label fan4 "FAN4"
+
+   label fan5 "FAN5"
+
+   ignore fan6

--- a/configs/Abit/AN8-SLI.conf
+++ b/configs/Abit/AN8-SLI.conf
@@ -1,0 +1,83 @@
+# lm_sensors configuration file for the Abit AN8-SLI motherboard
+
+# 2006-05-29, Hans de Goede <j.w.r.degoede@hhs.nl>
+
+# Comments welcome!
+
+
+
+chip "abituguru-*"
+
+
+
+### Voltages
+
+
+
+   label in0 "CPU Core Voltage"
+
+   label in1 "DDR Voltage"
+
+   label in2 "DDR VTT Voltage"
+
+   label in3 "nForce4 Standby Voltage"
+
+   label in4 "CPU VDDA 2.5V Voltage"  
+
+   label in5 "HyperTransport Voltage" 
+
+   label in6 "nForce4 Voltage"
+
+   label in7 "ATX +5V"
+
+   compute in7 @*1.788 , @/1.788
+
+   label in8 "ATX +3.3V"
+
+   compute in8 @*1.248 , @/1.248
+
+   label in9 "ATX 5VSB Voltage" 
+
+   compute in9 @*1.788 , @/1.788
+
+   label in10 "ATX +12V"
+
+   compute in10 @*4.153 , @/4.153
+
+
+
+### Temperatures
+
+
+
+   label temp1 "CPU Temperature"
+
+   label temp2 "SYS Temperature"
+
+   label temp3 "PWM Temperature" 
+
+   ignore temp4
+
+   ignore temp5
+
+   ignore temp6
+
+   ignore temp7
+
+
+
+### Fans
+
+
+
+   label fan1 "CPU FAN Speed"
+
+   label fan2 "NF4 FAN Speed"
+
+   label fan3 "SYS FAN Speed"
+
+   label fan4 "OTES1 FAN Speed"
+
+   label fan5 "OTES2 FAN Speed"
+
+   label fan6 "AUX FAN Speed"

--- a/configs/Abit/AV8.conf
+++ b/configs/Abit/AV8.conf
@@ -1,0 +1,83 @@
+# lm_sensors configuration file for the Abit AV8 motherboard
+
+# 2006-05-29, Hans de Goede <j.w.r.degoede@hhs.nl>
+
+# Comments welcome!
+
+
+
+chip "abituguru-*"
+
+
+
+### Voltages
+
+
+
+   label in0 "CPU Core Voltage"
+
+   label in1 "DDR Voltage"
+
+   label in2 "DDR VTT Voltage"
+
+   label in3 "NB Voltage"
+
+   label in4 "SB Voltage"
+
+   label in5 "HyperTransport Voltage"
+
+   label in6 "AGP VDDQ Voltage"
+
+   label in7 "ATX +5V"
+
+   compute in7 @*1.788 , @/1.788
+
+   label in8 "ATX +3.3V"
+
+   compute in8 @*1.248 , @/1.248
+
+   label in9 "Standby Voltage (+5V)"
+
+   compute in9 @*1.788 , @/1.788 
+
+   label in10 "3VDual Voltage"   
+
+   compute in10 @*1.248 , @/1.248
+
+
+
+### Temperatures
+
+
+
+   label temp1 "CPU Temperature"
+
+   label temp2 "SYS Temperature"
+
+   label temp3 "PWM Temperature"
+
+   ignore temp4
+
+   ignore temp5
+
+   ignore temp6
+
+   ignore temp7
+
+
+
+### Fans
+
+
+
+   label fan1 "CPU FAN Speed"
+
+   label fan2 "NB FAN Speed"  
+
+   label fan3 "SYS FAN Speed"
+
+   label fan4 "AUX1 FAN Speed"
+
+   label fan5 "AUX2 FAN Speed"
+
+   ignore fan6

--- a/configs/Abit/AX8.conf
+++ b/configs/Abit/AX8.conf
@@ -1,0 +1,83 @@
+# lm_sensors configuration file for the Abit AX8 motherboard
+
+# 2006-05-29, Hans de Goede <j.w.r.degoede@hhs.nl>
+
+# Comments welcome!
+
+
+
+chip "abituguru-*"
+
+
+
+### Voltages
+
+
+
+   label in0 "CPU Core Voltage"
+
+   label in1 "DDR Voltage"
+
+   label in2 "DDR VTT Voltage"
+
+   label in3 "NB Voltage"
+
+   label in4 "SB Voltage"
+
+   label in5 "HyperTransport Voltage"
+
+   label in6 "ATX +5V"
+
+   compute in6 @*1.788 , @/1.788
+
+   label in7 "ATX +3.3V"
+
+   compute in7 @*1.248 , @/1.248
+
+   label in8 "Standby Voltage (+5V)"
+
+   compute in8 @*1.788 , @/1.788
+
+   label in9 "ATX +12V"
+
+   compute in9 @*4.153 , @/4.153
+
+   ignore in10
+
+
+
+### Temperatures
+
+
+
+   label temp1 "CPU Temperature"
+
+   label temp2 "SYS Temperature"
+
+   label temp3 "PWM Temperature"
+
+   ignore temp4
+
+   ignore temp5
+
+   ignore temp6
+
+   ignore temp7
+
+
+
+### Fans
+
+
+
+   label fan1 "CPU FAN Speed"
+
+   label fan2 "NB FAN Speed"
+
+   label fan3 "SYS FAN Speed"
+
+   label fan4 "AUX FAN Speed"
+
+   ignore fan5
+
+   ignore fan6

--- a/configs/Abit/Aa7-Max.conf
+++ b/configs/Abit/Aa7-Max.conf
@@ -1,0 +1,83 @@
+# lm_sensors configuration file for the Abit Aa7-Max motherboard
+
+# 2006-05-29, Hans de Goede <j.w.r.degoede@hhs.nl>
+
+# Comments welcome!
+
+
+
+chip "abituguru-*"
+
+
+
+### Voltages
+
+
+
+   label in0 "CPU Core Voltage"
+
+   label in1 "DDR Voltage"
+
+   label in2 "DDR VTT Voltage"
+
+   label in3 "ATX +12V"
+
+   compute in3 @*4.153 , @/4.153
+
+   label in4 "FSB VTT Voltage"  
+
+   label in5 "NB Voltage"
+
+   label in6 "NB 2.5V Voltage"
+
+   label in7 "ATX +5V Voltage"
+
+   compute in7 @*1.788 , @/1.788
+
+   label in8 "ATX +3.3V Voltage"
+
+   compute in8 @*1.248 , @/1.248
+
+   label in9 "5VDual Voltage"   
+
+   compute in9 @*1.788 , @/1.788
+
+   ignore in10
+
+
+
+### Temperatures
+
+
+
+   label temp1 "CPU Temperature"
+
+   label temp2 "SYS Temperature"
+
+   label temp3 "PWM1 Temperature"
+
+   label temp4 "PWM2 Temperature"
+
+   ignore temp5
+
+   ignore temp6
+
+   ignore temp7
+
+
+
+### Fans
+
+
+
+   label fan1 "CPU FAN Speed"
+
+   label fan2 "NB FAN Speed"  
+
+   label fan3 "SYS FAN Speed"
+
+   label fan4 "AUX1 FAN Speed"
+
+   label fan5 "AUX2 FAN Speed"
+
+   ignore fan6

--- a/configs/Abit/Ag7.conf
+++ b/configs/Abit/Ag7.conf
@@ -1,0 +1,83 @@
+# lm_sensors configuration file for the Abit Ag7 motherboard
+
+# 2006-05-29, Hans de Goede <j.w.r.degoede@hhs.nl>
+
+# Comments welcome!
+
+
+
+chip "abituguru-*"
+
+
+
+### Voltages
+
+
+
+   label in0 "CPU Core Voltage"
+
+   label in1 "DDR Voltage"
+
+   label in2 "DDR VTT Voltage"
+
+   label in3 "ATX +12V"
+
+   compute in3 @*4.153 , @/4.153
+
+   label in4 "FSB VTT Voltage"  
+
+   label in5 "NB Voltage"
+
+   label in6 "NB 2.5V Voltage"
+
+   label in7 "ATX +5V Voltage"
+
+   compute in7 @*1.788 , @/1.788
+
+   label in8 "ATX +3.3V Voltage"
+
+   compute in8 @*1.248 , @/1.248
+
+   label in9 "5VDual Voltage"   
+
+   compute in9 @*1.788 , @/1.788
+
+   ignore in10
+
+
+
+### Temperatures
+
+
+
+   label temp1 "CPU Temperature"
+
+   label temp2 "SYS Temperature"
+
+   label temp3 "PWM1 Temperature"
+
+   label temp4 "PWM2 Temperature"
+
+   ignore temp5
+
+   ignore temp6
+
+   ignore temp7
+
+
+
+### Fans
+
+
+
+   label fan1 "CPU FAN Speed"
+
+   label fan2 "NB FAN Speed"  
+
+   label fan3 "SYS FAN Speed"
+
+   label fan4 "AUX1 FAN Speed"
+
+   label fan5 "AUX2 FAN Speed"
+
+   ignore fan6

--- a/configs/Abit/KN9-Ultra.conf
+++ b/configs/Abit/KN9-Ultra.conf
@@ -1,0 +1,64 @@
+# "My best guesses at my ABIT KN9 Ultra" Contributed by Dawn Light
+# Based on "Winbond W83627EHF configuration originally contributed by Leon Moonen"
+
+chip "w83627ehf-*"
+
+    label in0 "CPU Core"
+    label in1 "DDR2"
+    label in2 "AVCC"
+    label in3 "3VCC"
+    label in4 "DDR2 VTT"
+    label in5 "PCIE"
+    label in6 "ATX +5V"
+    label in7 "VSB"
+    label in8 "VBAT"
+    label in9 "ATX +12V"
+    compute in1 @*(1+(10/10)),  @/(1+(10/10))
+    compute in6 @*(1+(22/10)),  @/(1+(22/10))
+    compute in9 @*(1+(61/10)),  @/(1+(61/10))
+    set in0_min   1.15
+    set in0_max   1.25
+    set in1_min   2.05
+    set in1_max   2.15
+    set in4_min   0.95
+    set in4_max   1.15
+    set in5_min   1.50*0.95
+    set in5_max   1.50*1.05
+    set in6_min   5.0*0.95
+    set in6_max   5.0*1.05
+    set in9_min   12.0*0.95
+    set in9_max   12.0*1.05
+
+# Set the 3.3V
+    set in2_min   3.3*0.95
+    set in2_max   3.3*1.05
+    set in3_min   3.3*0.95
+    set in3_max   3.3*1.05
+    set in7_min   3.3*0.95
+    set in7_max   3.3*1.05
+    set in8_min   3.3*0.90
+    set in8_max   3.3*1.10
+
+# Fans
+    label fan1      "SYS Fan"
+    label fan2      "CPU Fan"
+    label fan3      "AUX1 Fan"
+    label fan4      "AUX2 Fan"
+#   ignore fan3
+    ignore fan4
+    set fan1_min    400
+    set fan2_min    2500
+    set fan3_min    890
+
+# Temperatures
+    label temp1     "Sys Temp"
+    label temp2     "CPU Temp"
+    label temp3     "PWM Temp"
+
+#   ignore temp3
+    set temp1_over  41
+    set temp1_hyst  50
+    set temp2_over  50
+    set temp2_hyst  60
+    set temp3_over  50
+    set temp3_hyst  60

--- a/configs/Abit/KV8-MAX3.conf
+++ b/configs/Abit/KV8-MAX3.conf
@@ -1,0 +1,83 @@
+# This configuration is derived from the AN7 configuration and currently
+# untested, it should work fine though. Please send any success or failure
+# using this config to: Hans de Goede <j.w.r.degoede@…>.
+
+# Notice that this motherboard contains version 1 of the uGuru. This version
+# does not seem to properly support autodetecting the type of the bank1
+# sensors, nor does the autodetection of the number of fan sensors work
+# properly on this chip. 
+
+
+# lm_sensors configuration file for the Abit KV8-MAX3 motherboard
+# 2006-06-24, Hans de Goede <j.w.r.degoede@hhs.nl>
+# Comments welcome!
+# Note it might be nessecaryto load the driver with the following params:
+# bank1_types=1,1,0,0,0,0,0,2,0,0,0,0,2,0,0,1 fan_sensors=5
+
+chip "abituguru-*"
+
+
+### Voltages
+
+
+   label in0 "CPU Core Voltage"
+
+   label in1 "DDR Voltage"
+
+   label in2 "DDR VTT Voltage"
+
+   label in3 "ATX +12V"
+   compute in3 @*4.153 , @/4.153
+
+   # I believe this is FSB VTT, in some Abit files its called GMCHVTT, below is the BIOS name
+   label in4 "AUXC Voltage"  
+
+   label in5 "NB Core Voltage"
+
+   label in6 "AGP VDDQ Voltage"
+
+   label in7 "ATX +5V Voltage"
+   compute in7 @*1.788 , @/1.788
+
+   label in8 "ATX +3.3V Voltage"
+   compute in8 @*1.248 , @/1.248
+
+   label in9 "Standby Voltage (+5V)"   
+   compute in9 @*1.788 , @/1.788
+
+   label in10 "3VDUAL Voltage"
+   compute in10 @*1.248 , @/1.248
+
+
+### Temperatures
+
+
+   label temp1 "CPU Temperature"
+
+   label temp2 "System Temperature"
+
+   label temp3 "PWM Temperature"
+
+   ignore temp4
+
+   ignore temp5
+
+   ignore temp6
+
+   ignore temp7
+
+
+### Fans
+
+
+   label fan1 "CPU FAN Speed"
+
+   label fan2 "NB FAN Speed"  
+
+   label fan3 "OTES FAN Speed"
+
+   label fan4 "FAN4"
+
+   label fan5 "FAN5"
+
+   ignore fan6

--- a/configs/Abit/Kv8Pro.conf
+++ b/configs/Abit/Kv8Pro.conf
@@ -1,0 +1,83 @@
+# lm_sensors configuration file for the Abit Kv8Pro motherboard
+
+# 2006-05-29, Hans de Goede <j.w.r.degoede@hhs.nl>
+
+# Comments welcome!
+
+
+
+chip "abituguru-*"
+
+
+
+### Voltages
+
+
+
+   label in0 "CPU Core Voltage"
+
+   label in1 "DDR Voltage"
+
+   label in2 "DDR VTT Voltage"
+
+   label in3 "NB Voltage"
+
+   label in4 "SB Voltage"
+
+   label in5 "HyperTransport Voltage"
+
+   label in6 "AGP VDDQ Voltage"
+
+   label in7 "ATX +5V"
+
+   compute in7 @*1.788 , @/1.788
+
+   label in8 "ATX +3.3V"
+
+   compute in8 @*1.248 , @/1.248
+
+   label in9 "Standby Voltage (+5V)"
+
+   compute in9 @*1.788 , @/1.788 
+
+   label in10 "3VDual Voltage"   
+
+   compute in10 @*1.248 , @/1.248
+
+
+
+### Temperatures
+
+
+
+   label temp1 "CPU Temperature"
+
+   label temp2 "SYS Temperature"
+
+   label temp3 "PWM Temperature"
+
+   ignore temp4
+
+   ignore temp5
+
+   ignore temp6
+
+   ignore temp7
+
+
+
+### Fans
+
+
+
+   label fan1 "CPU FAN Speed"
+
+   label fan2 "NB FAN Speed"  
+
+   label fan3 "SYS FAN Speed"
+
+   label fan4 "AUX1 FAN Speed"
+
+   label fan5 "AUX2 FAN Speed"
+
+   ignore fan6

--- a/configs/Abit/VA-20.conf
+++ b/configs/Abit/VA-20.conf
@@ -1,0 +1,41 @@
+#### Abit VA-20 contributed by DawnLight ####
+
+chip "it87-*" "it8712-*"
+
+    label in0 "CPU VCore"
+    label in1 "+2.5V"
+    label in2 "+3.3V"
+    label in3 "+5V"
+    label in4 "+12V"
+    ignore in5
+    ignore in6
+    ignore in7
+    label in8 "VBat"
+
+    ignore  vid
+
+    compute in3 ((6.8/10)+1)*@ ,  @/((6.8/10)+1)
+    compute in4 ((30/10) +1)*@  , @/((30/10) +1)
+    
+    set in0_min 1.55 * 0.95
+    set in0_max 1.55 * 1.05
+    set in1_min 2.4
+    set in1_max 2.6
+    set in2_min 3.3 * 0.95
+    set in2_max 3.3 * 1.05
+    set in3_min 5.0 * 0.95
+    set in3_max 5.0 * 1.05
+    set in4_min 12.5 * 0.95
+    set in4_max 12.5 * 1.05
+
+    label temp1       "M/B Temp"
+    set   temp1_over  44
+    set   temp1_low   15
+    label temp2       "CPU Temp"
+    set   temp2_over  45
+    set   temp2_low   15
+    ignore temp3
+
+    set fan1_min 3000
+    ignore fan2
+    ignore fan3

--- a/configs/Asus/H87-Pro.conf
+++ b/configs/Asus/H87-Pro.conf
@@ -1,0 +1,69 @@
+# Configuration file for ASUS H87-PRO
+# 2014-01-21/mg
+
+chip "nct6791-*"
+
+label in0 "Vcore"
+  compute in0  @*2    , @/2
+
+label in1 "+5V"
+  compute in1 @ * (40/8), @ / (40/8)
+  set in1_min 5 * 0.95
+  set in1_max 5 * 1.05
+
+label in2 "AVCC"
+  set in2_min 3.3 * 0.95
+  set in2_max 3.3 * 1.05
+
+label in3 "+3.3V"
+  set in3_min 3.3 * 0.95
+  set in3_max 3.3 * 1.05
+
+label in4 "+12V"
+  compute  in4  @ * (96/8), @ / (96/8)
+  set in4_min 12 * 0.95
+  set in4_max 12 * 1.05
+
+ignore in5 # always 0.17V here
+ignore in6 # always 0.82V here
+
+label in7 "3VSB"
+  set in7_min 3.3 * 0.95
+  set in7_max 3.3 * 1.05
+
+label in8 "Vbat"
+  set in8_min 3.0 * 0.90
+  set in8_max 3.3 * 1.10
+
+ignore in9
+ignore in10
+ignore in11
+ignore in12
+ignore in13
+ignore in14
+
+label fan1 "CHA_FAN1"
+  set fan1_min 300
+
+label fan2 "CPU fan"
+  set fan2_min 300
+
+label fan3 "CHA_FAN2"
+  set fan3_min 300
+
+label fan4 "CHA_FAN3"
+  set fan4_min 300
+
+ignore fan5	# does not exist on this MB
+
+ignore temp1		# SYSTIN
+ignore temp3		# AUXTIN, gets smaller under load
+ignore temp4		# AUXTIN1
+ignore temp5		# AUXTIN2
+ignore temp6		# AUXTIN3
+ignore intrusion0
+ignore intrusion1
+ignore beep_enable
+ignore temp8		# PCH_CHIP_CPU_MAX_TEMP
+ignore temp9		# PCH_CHIP_TEMP
+ignore temp10		# PCH_CPU_TEMP

--- a/configs/Asus/KFN4-DRE.conf
+++ b/configs/Asus/KFN4-DRE.conf
@@ -1,0 +1,62 @@
+# Contributed by Mark Nienberg
+
+# sensors-detect 2.10.6 suggested the w83627thf chip, but that is wrong. The
+# board actually has a Winbond W83792D according to the manual.
+
+
+# Here are configurations for Winbond W83792AD/D chip.
+chip "w83792d-*"
+
+    label in0 "VCoreA"
+    label in1 "VCoreB"
+    label in2 "VIN0"
+    label in3 "VIN1"
+    label in4 "VIN2"
+    label in5 "VIN3"
+    label in6 "5VCC"
+    label in7 "5VSB"
+    label in8 "VBAT"
+
+# These are the corresponding fan names from motherboard manual.
+# Rear_Fan1 through Rear_Fan4 are not read by lm_sensors, but the manual
+# says that all fans are controlled by "smart fan" in BIOS.
+# fan6 doesn not show up in sensor output for me.
+    label fan1 "Frnt_Fan3"
+    label fan2 "Frnt_Fan1"
+    label fan3 "Frnt_Fan2"
+    label fan4 "Frnt_Fan4"
+    label fan5 "Frnt_Fan5"
+#   label fan6 "Nothing"
+    label fan7 "Frnt_Fan6"
+
+# Here is my installed fans layout
+# Yours will be different
+#    ignore fan1
+#    label fan2 "Case Fan"
+#    ignore fan3
+#    label fan4 "CPU1 Fan"
+#    label fan5 "P/S Fan"
+#    ignore fan6
+#    ignore fan7
+
+# Fix Case fan because speed read 0 at low speeds.
+#    set fan2_div 8
+
+# Temps - I'm guessing here.
+# Add 5 degrees to CPU temperatures to match BIOS
+# (very limited data on which to base this)
+    compute temp2 @+5,@-5
+    compute temp3 @+5,@-5
+
+    label temp1 "MB Temp"
+    label temp2 "CPU1 Temp"
+    label temp3 "CPU2 Temp"
+
+# Ignore chassis alarm, I don't have one
+    ignore chassis
+
+# prevent alarm on in0, the actual value is about 1.1
+# this is probably due to my low power 55 watt CPU
+    set in0_min 0.8
+    set in0_max 1.6
+

--- a/configs/Asus/KGPE-D16.conf
+++ b/configs/Asus/KGPE-D16.conf
@@ -1,0 +1,95 @@
+# Configuration file for the Asus KGPE-D16 motherboard, 
+# contributed by Seth Bardash.
+
+chip "w83795g-*" "w83795ag-*"
+
+    label in0  "VCORE1"
+    label in1  "VCORE2"
+    label in2  "P1DDR3"
+    label in3  "P2DDR3"
+    label in4  "P1_+1.2V"
+    label in5  "P2_+1.2V"
+    label in6  "P1_VDDNB"
+    label in7  "+1.8V"
+    label in8  "+1.2V"
+    label in9  "+1.1V"
+    label in10 "+5VSB"
+    label in12 "+3.3V"
+    label in13 "+3.3VSB"
+    label in14 "VBAT"
+    label in15 "+12V"
+    label in16 "+5V"    
+    
+    label temp2 "TR1 Tempearture"
+    label temp3 "TR2 Temperature"
+    label temp7 "CPU1 Temperature"
+    label temp8 "CPU2 Temperature"
+
+    label fan1 "CPU_FAN1"
+    label fan2 "CPU_FAN2"
+    label fan3 "FRNT_FAN1"
+    label fan4 "FRNT_FAN2"
+    label fan5 "FRNT_FAN3"
+    label fan6 "FRNT_FAN4"
+    label fan7 "FRNT_FAN5"
+    label fan8 "REAR_FAN1"
+    
+    compute in10 (3.2)*@ , @/(3.2)
+    compute in15 (12)*@ , @/(12)
+    compute in16 (3.2)*@ , @/(3.2)
+    
+    set in0_min 0.72
+    set in0_max 1.43
+    set in1_min 0.72
+    set in1_max 1.43
+    set in2_min 1.125
+    set in2_max 1.625
+    set in3_min 1.125
+    set in3_max 1.625
+    set in4_min 1.14
+    set in4_max 1.26
+    set in5_min 1.14
+    set in5_max 1.26
+    set in6_min 0.92
+    set in6_max 1.21
+    set in7_min 1.62
+    set in7_max 1.98
+    set in8_min 1.08
+    set in8_max 1.32
+    set in9_min 0.99
+    set in9_max 1.21
+    set in10_min 4.5
+    set in10_max 5.5
+    set in12_min 2.97
+    set in12_max 3.63
+    set in13_min 2.97
+    set in13_max 3.63
+    set in14_min 1.9
+    set in14_max 3.6
+    set in15_min 10.8
+    set in15_max 13.2
+    set in16_min 4.5
+    set in16_max 5.5
+    
+    set fan1_min 700
+    set fan2_min 700
+    set fan3_min 700
+    set fan4_min 700
+    set fan5_min 700
+    set fan6_min 700
+    set fan7_min 700
+    set fan8_min 700
+
+# DO NOT add temp5_crit, temp5_crit_hyst, temp6_crit and temp6_crit_hyst
+# Because these features are configuration of smart fan.
+#    set temp2_max       60
+#    set temp2_max_hyst  55
+#    set temp3_max       60
+#    set temp3_max_hyst  55
+
+# temp7_max and temp7_max_hyst are also features of temp8    
+    set temp7_max       70
+    set temp7_max_hyst  65
+
+    ignore beep_enable
+

--- a/configs/Asus/M2N-SLI_Deluxe.conf
+++ b/configs/Asus/M2N-SLI_Deluxe.conf
@@ -1,0 +1,89 @@
+# Contributed by Matt Roberds.
+
+
+# Second cut at a minimal sensors3.conf for Asus M2N-SLI Deluxe motherboard
+# Based on existing entries in sensors3.conf and Jean Delvare's configuration
+# for the Asus M2N32-SLI
+# Matt Roberds, 21 Feb 2008
+
+
+chip "it8716-*"
+
+# Voltages
+
+    label  in0  "VCore"
+    label  in1  "VDDR"     # Not in BIOS
+    ignore in2             # 3.3 V is monitored by adt7475
+    label  in3  "+5V"      # VCC
+    label  in4  "+12V"
+    ignore in5             # -12 V not monitored
+    ignore in6             #  -5 V not monitored
+    label  in7  "5VSB"     # Not in BIOS
+    label  in8  "VBat"     # Not in BIOS
+
+    # Vcore, VDDR, and Vbat are connected directly, so no compute
+    # line is needed for these. For +5V, +12V and 5VSB, the default
+    # resistors seem to have been used.
+    compute in3  ((6.8/10)+1)*@ , @/((6.8/10)+1)
+    compute in4  ((30/10)+1)*@  , @/((30/10)+1)
+    compute in7  ((6.8/10)+1)*@ , @/((6.8/10)+1)
+
+# Temperatures
+
+# Not sure.  temp1 always reads close to what k8temp reports for Core0,
+# and to what the BIOS reports as the CPU temperature.  temp2 is between
+# temp1 and temp3; it is close to what the BIOS reports as the motherboard
+# temperature.  temp3 always reads approximate ambient temperature.
+
+    label temp1 "CPU Temp"
+    label temp2 "MB Temp"
+    label temp3 "MB Temp"
+
+# Fans
+
+    label  fan1 "CPU Fan"
+    label  fan2 "Chassis Fan 1"
+    label  fan3 "Power Supply Fan"
+
+    # Ignore fans you don't have
+#   ignore fan2
+#   ignore fan3
+
+
+chip "adt7475-*"
+
+# Note: this section depends on some further hacks I have made to
+# Jordan Crouse's driver
+
+# Voltages
+
+    ignore in1
+    label  in2  "+3.3V"
+
+# Temperatures
+
+# temp1 and temp3 don't appear to be hooked up; temp2 is on board the
+# adt7475 chip itself.
+
+    ignore temp1
+    label  temp2  "ADT7475 Temp"
+    ignore temp3
+
+# Fans
+
+    label  fan1 "Chassis Fan 4"
+    label  fan2 "Chassis Fan 2"
+    label  fan3 "Chassis Fan 3"
+    ignore fan4
+
+    # Ignore fans you don't have
+#   ignore fan1
+#   ignore fan2
+#   ignore fan3
+
+
+chip "k8temp-*"
+
+   label temp1 "core0 temp"
+   label temp3 "core1 temp"
+

--- a/configs/Asus/M3A78-CM.conf
+++ b/configs/Asus/M3A78-CM.conf
@@ -1,0 +1,41 @@
+# Sample configuration file contributed by Martin Desormeaux. Note that this
+# board also implements the ATK0110 interface, so starting with kernel 2.6.30
+# you can use the asus_atk0110 driver instead of the it87 driver. It is
+# suggested you don't use both at once.
+
+
+chip "it8712-*"
+ # The values below have been tested on Asus M3A78-CM motherboards.
+
+     label in0 "VCore"
+     ignore in1
+     label in2 "+3.3V"
+     ignore in3
+     label in4 "+12V"
+     label in5 "+5V"
+     ignore in6
+     ignore in7
+     label in8 "VBat"
+     ignore cpu0_vid
+     compute in4 ((28/10) +1)*@  , @/((28/10) +1)
+     compute in5 @*(1+(22/10)),  @/(1+(22/10))
+     set in0_min  1.30 * 0.95
+     set in0_max  1.30 * 1.05
+     set in2_min  3.3 * 0.95
+     set in2_max  3.3 * 1.05
+     set in4_min   12 * 0.95
+     set in4_max   12 * 1.05
+     set in5_min    5 * 0.95
+     set in5_max    5 * 1.05
+
+     set temp1_type 2
+     set temp2_type 2
+     set temp3_type 3
+     ignore temp3
+     label temp1       "CPU Temp"
+     label temp2       "M/B Temp"
+
+     label fan1 "CPU Fan"
+     label fan2 "Chassis Fan"
+     label fan3 "Power Fan"
+

--- a/configs/Asus/M5A97-Pro.conf
+++ b/configs/Asus/M5A97-Pro.conf
@@ -1,0 +1,31 @@
+# Configuration file contributed by Felipe Almeida Lessa.
+
+
+# Asus M5A97 PRO
+# http://blog.felipe.lessa.nom.br/?p=93
+
+chip "k10temp-pci-00c3"
+     label temp1 "CPU Temp (rel)"
+
+chip "it8721-*"
+     label  in0 "+12V"
+     label  in1 "+5V"
+     label  in2 "Vcore"
+     ignore in4
+     ignore in5
+     ignore in6
+
+     compute in0  @ * (515/120), @ / (515/120)
+     compute in1  @ * (215/120), @ / (215/120)
+
+     ignore temp3
+     label temp1 "CPU Temp"
+     label temp2 "M/B Temp"
+
+     label fan1 "CPU Fan"
+     label fan2 "Chassis Fan"
+     label fan3 "Power Fan"
+
+     ignore intrusion0
+
+

--- a/configs/Asus/P3-PH4C.conf
+++ b/configs/Asus/P3-PH4C.conf
@@ -1,0 +1,70 @@
+# Winbond W83627EHF configuration originally contributed by Leon Moonen
+# Modified for ASUS P3-PH4C by Florian Kleinmanns
+chip "w83627ehf-*" "w83627dhg-*"
+
+    label in0 "VCore"
+    label in1 "+12V"
+    label in2 "AVCC"
+# ACPI <http://www.lm-sensors.org/wiki/AsusFormulaHacking> says nothing about AVCC, so you might want to uncomment:
+#ignore in2
+    label in3 "+3.3V"
+    ignore in4
+    label in5 "+5V"
+    ignore in6
+    label in7 "VSB"
+    label in8 "VBAT"
+# ACPI says nothing about VSB and VBAT, so you might want to uncomment:
+#ignore in7
+#ignore in8
+
+# The W83627DHG has no in9, uncomment the following line
+    ignore in9
+
+# ACPI says:
+    compute in1 @*(1+(56/10)),  @/(1+(56/10))
+# ACPI says... but obviously wrong:
+#    compute in3 @*(1+(34/34)),  @/(1+(34/34))
+# ACPI says:
+    compute in5 @*(1+(22/10)),  @/(1+(22/10))
+# ACPI says nothing about in8, so I guess:
+    compute in8 @*1.42, @/1.42
+
+# Values for Conroe-L (Celeron 420/430/440)
+    set in0_min   1.0*0.95
+    set in0_max   1.3375*1.05
+
+    set in1_min   12.0*0.9
+    set in1_max   12.0*1.1
+    set in2_min   3.3*0.95
+    set in2_max   3.3*1.05
+    set in3_min   3.3*0.95
+    set in3_max   3.3*1.05
+    set in5_min   5.0*0.95
+    set in5_max   5.0*1.05
+    set in7_min   3.3*0.95
+    set in7_max   3.3*1.05
+    set in8_min   3.0*0.85
+    set in8_max   3.0*1.15
+
+# Fans
+   label fan1      "Case Fan"
+   label fan2      "CPU Fan"
+   label fan3      "Aux Fan"
+   ignore fan1
+   ignore fan3
+   ignore fan4
+   ignore fan5
+   set fan2_min    600
+
+# Temperatures
+   label temp1     "Sys Temp"
+   label temp2     "CPU Temp"
+   label temp3     "AUX Temp"
+   
+  ignore temp3
+# ACPI says:
+  set temp1_over  60
+  set temp1_hyst  55
+  set temp2_over  45
+  set temp2_hyst  40
+

--- a/configs/Asus/P5B-E.conf
+++ b/configs/Asus/P5B-E.conf
@@ -1,0 +1,95 @@
+# Contributed by Frank Enderle.
+
+
+# This is the sensors.conf configuration file for ASUS P5B-E (and maybe it's different versions)
+# Everythings based on the guide at http://www.lm-sensors.org/wiki/AsusFormulaHacking. The formulas
+# and ranges are based on the /proc/acpi/dsdt readings of a P5B-E board with a E6600 CPU.
+
+chip "w83627dhg-*"
+# == VOLTAGES ==
+# Vcore
+    label in0 "Vcore"
+    set in0_min 0.85
+    set in0_max 1.6
+
+# +12V
+    label in1 "+12V"
+    compute in1 @*(66/10),  @/(66/10)
+    set in1_min 10.2
+    set in1_max 13.8
+
+# unused
+    ignore in2
+
+# +3.3V
+    label in3 "+3.3V"
+    # this formula is stored in the ACPI, but it seems not to work
+    # compute in3 @*(68/34),  @/(68/34)
+    set in3_min 2.97
+    set in3_max 3.63
+
+# unused
+    ignore in4
+
+# +5V
+    label in5 "5V"
+    compute in5 @*(32/10),  @/(32/10)
+    set in5_min 4.5
+    set in5_max 5.5
+
+# unused
+    ignore in6
+    ignore in7
+    ignore in8
+    ignore in9
+
+# == TEMPERATURES ==
+# Mainboard
+    label temp1 "Sys Temp"
+    set temp1_over 95
+    set temp1_hyst 60
+
+# CPU
+    label temp2 "CPU Temp"
+    set temp2_over 95
+    set temp2_hyst 45
+
+# unused
+    ignore temp3
+
+# == FANS ==
+# If you miss a certain fan set it to ignore
+# Chassis 1
+   # ignore fan1
+   label fan1 "Cha1 Fan"
+   set fan1_min 800
+
+# CPU
+   # ignore fan2
+   label fan2 "CPU Fan"
+   set fan2_min 600
+
+# Powersupply
+   ignore fan3
+   #label fan3 "Pwr Fan"
+   #set fan3_min 800
+
+# unused
+   ignore fan4
+
+# Chassis 2
+   # ignore fan5
+   label fan5 "Cha2 Fan"
+   set fan5_min 800
+
+# == CORE TEMPERATURES ==
+# This requires the coretemp patch applied
+# Maximums are autodetected by the driver depending on the CPU
+# Core0
+chip "coretemp-isa-0000"
+   label temp1 "Core0 Temp"
+
+# Core1
+chip "coretemp-isa-0001"
+   label temp1 "Core1 Temp"
+

--- a/configs/Asus/P5E3.conf
+++ b/configs/Asus/P5E3.conf
@@ -1,0 +1,59 @@
+# Contributed by Alexey Torkhov
+
+# Main difference with existing config is different coefficient in voltage
+# formula and different input (in5 instead of in6) for +5V.
+
+
+# This is for an Asus P5E3
+chip "w83627dhg-*"
+
+    label in0 "VCore"
+    label in1 "+12V"
+    label in3 "+3.3V"
+    label in5 "+5V"
+
+    ignore in2
+    ignore in4
+    ignore in6
+    ignore in7
+    ignore in8
+
+# +12V is in1 and +5V is in5
+    compute in1 @*(1+(60/10)),  @/(1+(60/10))
+    compute in5 @*(1+(20/10)),  @/(1+(20/10))
+    # 10% tolerance for 12V
+    set in1_min   12.0*0.9
+    set in1_max   12.0*1.1
+
+    # 5% for others
+    set in5_min   5.0*0.95
+    set in5_max   5.0*1.05
+
+# Set the 3.3V
+    set in3_min   3.3*0.95
+    set in3_max   3.3*1.05
+
+# Fans
+   label fan1      "Case Fan"
+   label fan2      "CPU Fan"
+   label fan3      "Aux Fan"
+#  ignore fan4
+#  ignore fan5
+   set fan1_min    600
+   set fan2_min    600
+   set fan3_min    600
+   set fan4_min    600
+   set fan5_min    600
+
+# Temperatures
+   label temp1     "Sys Temp"
+   label temp2     "CPU Temp"
+   ignore temp3
+
+   set temp1_max       60
+   set temp1_max_hyst  55
+   set temp2_max       72
+   set temp2_max_hyst  67
+   set temp3_max       60
+   set temp3_max_hyst  55
+

--- a/configs/Asus/P5N32-E_SLI_Plus.conf
+++ b/configs/Asus/P5N32-E_SLI_Plus.conf
@@ -1,0 +1,118 @@
+# Contributed by Stéphane Urbanovski.
+
+
+# Linux sensor configuration for an Asus P5N32-E SLI Plus
+# 5/2007 s.urbanovski#ac-nancy-metz.fr
+# (see http://www.lm-sensors.org/wiki/AsusFormulaHacking)
+
+chip "w83791d-*"
+
+## Voltage control :
+
+	label in0 "1.2VHT Voltage"
+	set in0_min 1.2
+	set in0_max 1.4
+	
+	label in1 "SB CORE Voltage"
+	set in1_min 1.3
+	set in1_max 1.7
+	
+	label in2 "CPU VTT Voltage"
+	set in2_min 1.1
+	set in2_max 1.4
+
+# not sure ...
+	ignore in3
+
+	label in4 "DDR2 TERM Voltage"
+	set in4_min 0.5
+	set in4_max 1.3
+	
+# not sure ...
+	ignore in5
+
+# not sure ...
+	label in6 "NB CORE Voltage"
+	set in6_min 1.1
+	set in6_max 1.6
+	
+# not sure ...
+	ignore in7
+	
+# pure speculation ...
+#	label in8 "Battery"
+#	set in8_min 2.5
+#	set in8_max 3.5
+	ignore in8
+
+# not sure ...
+	label in9 "MEMORY Voltage"
+	set in9_min 1.6
+	set in9_max 2.5
+
+## Fan control
+
+	label fan1 "OPT1 FAN Speed"
+	label fan2 "OPT2 FAN Speed"
+	label fan3 "OPT3 FAN Speed"
+	label fan4 "OPT4 FAN Speed"
+	label fan5 "OPT5 FAN Speed"
+
+## Temp control
+
+	ignore temp1
+	ignore temp2
+	ignore temp3
+
+
+
+chip "it8718-*"
+
+## Voltage control :
+
+# not sure ...
+	label in0 "CPU Core Voltage"
+	set in0_min 1.1
+	set in0_max 1.5
+	compute in0 @+0.08,  @-0.08
+	
+	label in1 "+3.3 Voltage"
+	set in1_min 3.00
+	set in1_max 3.60
+	
+	ignore in2
+	
+	label in3 "+5.0 Voltage"
+	set in3_min 4.50
+	set in3_max 5.50
+	compute in3 @*(84/50),  @*(50/84)
+	
+	label in4 "+12.0 Voltage"
+	set in4_min 11.2
+	set in4_max 13.2
+	compute in4 @*4,  @/4
+	
+	ignore in5
+	
+	label in6 "VIN6 ?"
+	
+	ignore in7
+	ignore in8
+	
+	ignore vid
+
+## Fan control
+
+	label fan1 "CPU FAN Speed"
+	label fan2 "CHA FAN Speed"
+
+## Temp control
+
+	label temp1 "CPU Temp"
+	set   temp1_over   50
+	set   temp1_low   15
+	
+	label temp2 "MB Temp"
+	set   temp2_over   55
+	set   temp2_low   15
+	ignore temp3

--- a/configs/Asus/P5PE-VM.conf
+++ b/configs/Asus/P5PE-VM.conf
@@ -1,0 +1,70 @@
+### Import note: separately listed for this motherboard, merged with config:
+
+# sensors-detect will report a W83627DHG device and suggest loading the
+# w83627ehf driver. However this motherboard has an ACPI BIOS which accesses
+# the W83627DHG device already, so using the w83627ehf driver is not safe and
+# thus discouraged.
+
+##################
+
+### Sensors configuration for Asus P5PE-VM motherboard
+### 2014-02-28, ianp <snailbox88-dev -at- yahoo -dot- com>
+### Comments are welcome.
+
+
+chip "w83627ehf-*"
+
+
+### Voltages
+
+   label  in1  "+12V"
+   ignore in4          # ignored (not used?)
+   label  in5  "+5V"
+   ignore in6          # ignore these
+   ignore in9          # as well (not used)
+   ignore cpu0_vid     # Always at 0 in my case, so ignore it
+
+   ### Scale +5V and +12V.
+
+   compute  in5  @*(1+22/10), @/(1+22/10)
+   compute  in1  @*(1+56/10), @/(1+56/10)
+
+   ### Set in0 according to CPU nominal voltage.
+
+   set in0_min   1.2000
+   set in0_max   1.3375
+   set in5_min   5 * 0.95
+   set in5_max   5 * 1.05
+   set in1_min  12 * 0.95
+   set in1_max  12 * 1.05
+
+### Temperatures
+
+   # temp3 is unidentified
+
+   label  temp1  "M/B Temp"
+   label  temp2  "CPU Temp"
+
+   ### Set according to preference.
+
+   set temp1_max      60
+   set temp1_max_hyst 55
+   set temp2_max      60
+   set temp2_max_hyst 55
+
+### Fans
+
+   ### Ignore fan3 and fan5. There are
+   ### only 2 fan connectors on this board.
+   ### fan4 is missing.
+
+   label  fan1  "CHA Fan"
+   label  fan2  "CPU Fan"
+   ignore fan3
+   ignore fan5
+
+   ### Set according to preference.
+
+   set fan1_min 0
+   set fan2_min 900
+

--- a/configs/Asus/P8H77-I.conf
+++ b/configs/Asus/P8H77-I.conf
@@ -1,0 +1,38 @@
+# lm-sensors configuration file for the Asus P8H77-I motherboard
+# Victor Serverov <serverov <at> gmail.com>
+# 29-Aug-2013
+#
+
+chip "it8771-*"
+
+   label in0 "Vcore"
+   label in1 "Vram"
+   label in2 "+12V"
+   label in3 "+5V"
+   label in4 "+3.3V"
+   ignore in5
+   ignore in6
+   ignore in7 # Value changes all the time
+
+   compute in2 @*(72/12), @/(72/12)
+   compute in3 @*(30/12), @/(30/12)
+   compute in4 @*(1978/1200), @/(1978/1200)
+
+   # Vcore limits for a Pentium G2020 processor
+   set in0_min 0.86 * 0.95
+   set in0_max 0.92 * 1.05
+   set in1_min 1.5 * 0.95
+   set in1_max 1.5 * 1.05
+   set in2_min 12.0 * 0.95
+   set in2_max 12.0 * 1.05
+   set in3_min 5.0 * 0.95
+   set in3_max 5.0 * 1.05
+   set in4_min 3.3 * 0.95
+   set in4_max 3.3 * 1.05
+
+   label fan1 "CPU Fan"
+   label fan2 "Chassis Fan"
+
+   label temp1 "CPU Temp"
+   label temp2 "M/B Temp"
+   ignore temp3

--- a/configs/Asus/P8P67_Pro.conf
+++ b/configs/Asus/P8P67_Pro.conf
@@ -1,0 +1,57 @@
+# Preliminary configuration file  contributed by Artem S. Tashkinov.
+
+
+chip "nct6776-*"
+# nct6776 values for Asus P8P67 PRO
+
+label in0 "Vcore"
+    set in0_min 0.75
+    set in0_max 1.35
+
+label in1 "+12V"
+    compute in1 @ * 12, @ / 12
+    set in1_min  12 * 0.95
+    set in1_max  12 * 1.05
+
+label in2 "AVCC"
+    set in2_min  3.3 * 0.95
+    set in2_max  3.3 * 1.05
+
+label in3 "+3.3V"
+    set in3_min  3.3 * 0.95
+    set in3_max  3.3 * 1.05
+
+label in4 "+5V"
+    compute in4 @ * 5, @ / 5
+    set in4_min  5 * 0.95
+    set in4_max  5 * 1.05
+
+# always reads +2.04V, ignoring
+ignore in5
+
+label in7 "3VSB"
+    set in7_min  3.3 * 0.95
+    set in7_max  3.3 * 1.05
+
+label in8 "Vbat"
+    set in8_min  3.3 * 0.95
+    set in8_max  3.3 * 1.05
+
+label temp1 "MB"
+    set temp1_max 50
+    set temp1_max_hyst 40
+
+# always reads -60C, ignoring
+ignore temp2
+
+label temp3 "MB's CPU sensor"
+
+label fan2 "CPU Fan"
+    set fan2_min  500
+
+# Ignore these fans if not present
+#ignore fan1
+#ignore fan3
+#ignore fan4
+#ignore fan5
+

--- a/configs/Asus/TUSI-M.conf
+++ b/configs/Asus/TUSI-M.conf
@@ -1,0 +1,49 @@
+# Asus TUSI-M motherboard configuration contributed by Dawn Light
+chip "it87-*"
+
+    label in0 "VCore 1"
+    label in1 "VCore 2"
+    label in2 "+3.3V"
+    label in3 "+5V"
+    label in4 "+12V"
+    label in5 "3.3 Stdby"
+    label in6 "-12V"
+    label in7 "Stdby"
+    label in8 "VBat"
+
+    set in0_min 1.5 * 0.95
+    set in0_max 1.5 * 1.05
+    set in1_min 2.4
+    set in1_max 2.6
+    set in2_min 3.3 * 0.95
+    set in2_max 3.3 * 1.05
+    set in3_min 5.0 * 0.95
+    set in3_max 5.0 * 1.05
+    set in4_min 12 * 0.90
+    set in4_max 12 * 1.10
+    set in5_min 3.3 * 0.95
+    set in5_max 3.3 * 1.05
+    set in6_max -12 * 0.90
+    set in6_min -12 * 1.10
+    set in7_min 5 * 0.95
+    set in7_max 5 * 1.05
+
+    ignore  vid
+
+    compute in2 @ * 2 , @ / 2
+    compute in3 ((6.8/10)+1)*@ ,  @/((6.8/10)+1)
+    compute in4 ((30/10) +1)*@  , @/((30/10) +1)
+    compute in6 (1+232/56)*@ - 4.096*232/56, (@ + 4.096*232/56)/(1+232/56)
+    compute in5 @ * 2 , @ / 2
+    compute in7 ((6.8/10)+1)*@ ,  @/((6.8/10)+1)
+
+    # Temperature
+    label temp1       "CPU Temp"
+#    ignore temp2
+#    ignore temp3
+
+   # Fans
+    label fan2 "CPU Fan"
+#    set fan2_min 3000
+#    ignore fan1
+#    ignore fan3

--- a/configs/Asus/TX97-E.conf
+++ b/configs/Asus/TX97-E.conf
@@ -1,0 +1,82 @@
+# lm_sensors 3 configuration file for the Asus TX97-E motherboard
+# 2005-11-14, Jean Delvare <jdelvare@suse.de>
+# Comments welcome!
+
+chip "lm78-*"
+
+### Voltages
+
+   # Vcore is monitored twice because this is a "dual plane" CPU
+   # (Intel Pentium 166 MMX).
+   label in0 "Vcore 1"
+   label in1 "Vcore 2"
+   label in2 "+3.3V"
+   label in3 "+5V"
+   label in4 "+12V"
+   label in5 "-12V"
+   label in6 "-5V"
+
+   compute in3 @*((6.8/10)+1),  @/((6.8/10)+1)
+   compute in4 @*((28/10)+1),   @/((28/10)+1)
+   compute in5 @*(-210/60.4),   @/(-210/60.4)
+   compute in6 @*(-90.9/60.4),  @/(-90.9/60.4)
+
+   # It looks like you can't trust VID readings when using a dual plane
+   # CPU (e.g. Intel Pentium MMX or AMD K6) on the TX97-E. It will report
+   # the "equivalent" (jumper-wise) single plane voltage. At least this is
+   # what I can observe since I use a Pentium 166 MMX, which uses 2.8V
+   # dual plane, and VID reads 3.4V, which is the same jumper combination
+   # for single plane. This also seems to suggest that the VID value comes
+   # from the motherboard and not the CPU itself as is the case with later
+   # models.
+   ignore cpu0_vid
+
+   set in0_min 2.7
+   set in0_max 2.9
+   set in1_min 2.7
+   set in1_max 2.9
+   set in2_min 3.3 * 0.95
+   set in2_max 3.3 * 1.05
+   set in3_min 5.0 * 0.95
+   set in3_max 5.0 * 1.05
+   set in4_min 12 * 0.95
+   set in4_max 12 * 1.05
+   set in5_min -12 * 0.95
+   set in5_max -12 * 1.05
+   set in6_min -5 * 0.95
+   set in6_max -5 * 1.05
+
+### Fans
+
+   label fan1 "Case Fan"
+   label fan2 "CPU Fan"
+   label fan3 "P/S Fan"
+
+   # I only have a CPU fan on this system. Note that the power supply fan
+   # header surprisingly did not seem to be powered anyway, so I couldn't
+   # have used it if I had wanted to.
+   ignore fan1
+   ignore fan3
+
+   set fan2_div 2
+   set fan2_min 4800
+
+### Temperatures
+
+   label temp1 "M/B Temp"
+
+   set temp1_max 40
+   set temp1_max_hyst 38
+
+chip "lm75-*"
+
+   label temp1 "CPU Temp"
+
+   # Contrary to most motherboards, the Asus TX97-E needs scaling,
+   # supposedly to compensate for the thermistor-to-CPU distance. The
+   # formula doesn't make much physical sense, but will give the same
+   # value as the BIOS displays.
+   compute temp1 @*2, @/2
+
+   set temp1_max 80	
+   set temp1_max_hyst 75	

--- a/configs/Biostar/N68S+.conf
+++ b/configs/Biostar/N68S+.conf
@@ -1,0 +1,122 @@
+# Configuration file contributed by Lee Marriott.
+
+
+# libsensors configuration file
+# -----------------------------
+#
+# This is a first attempt at a custom configuration file for the Biostar N68S+.
+# This custom configuration file should be copied to /etc/sensors.d/Biostar-N68S+.conf.
+#
+# Custom configuration files for some specific mainboards can be found at
+# http://www.lm-sensors.org/wiki/Configurations
+
+# READ THE MAN PAGE DOCUMENTATION OF 'sensors.conf' FOR MORE
+# COMPLETE INFORMATION. ie:
+
+# man sensors.conf
+
+# Regarding the Biostar N68S+ motherboard: This motherboard supports
+# both manual overclocking by individual settings and preconfigured
+# overclocking using predefined sets of overclock settings.
+
+chip "it8716-*"
+
+# All labels set to match Biostar N68S+ BIOS displayed labels. See
+# the 'PC Health' screen in the BIOS.
+
+# Voltage settings
+
+    label in0 "  Vcore"
+    label in1 "Chipset"
+    ignore in2           # +3.3 V not in BIOS
+    label in3 "   +5 V"  # VCC
+    label in4 "  +12 V"
+    label in5 "    DDR"
+    label in6 "     HT"
+    label in7 "   5VSB"
+    label in8 "   Vbat"
+
+    compute in3 ((6.8/10)+1)*@ , @/((6.8/10)+1)
+    compute in4 ((30/10)+1)*@ , @/((30/10)+1)
+    compute in7 ((6.8/10)+1)*@ , @/((6.8/10)+1)
+
+    ignore cpu0_vid
+
+# Other than +3.3, +5.0 and +12.0 voltages (here set plus/minus 10%), the
+# indicated min/max voltages are a guess based on present measurements
+# and similar to those on my Asus m/b.
+# 
+
+    set in0_min   0.80
+    set in0_max   1.80
+    set in1_min   1.1
+    set in1_max   1.76
+#    set in2_min   3.3 * 0.90
+#    set in2_max   3.3 * 1.10
+    set in3_min   5.0 * 0.90
+    set in3_max   5.0 * 1.10
+    set in4_min  12.0 * 0.90
+    set in4_max  12.0 * 1.10
+    set in5_min   1.60
+    set in5_max   2.20
+    set in6_min   0.95
+    set in6_max   1.4
+    set in7_min   5.0 * 0.90
+    set in7_max   5.0 * 1.10
+
+# Fan settings
+
+    label fan1 "CPU fan"
+    label fan2 "Sys1fan"
+    label fan3 " NB fan"
+
+    # Ignore fans you don't have
+   ignore fan3
+
+#
+# The Biostart N68S+ is based upon the nVidia GeForce 7025/nForce 630a
+# chipset and comes with active (fan based) cooling.
+
+# Biostar N68S+ can allow 0 rpm for the CPU fan when in SMART
+# fan control mode. Set min speeds as applicable for your system.
+
+#    set fan1_min 1000
+    set fan1_min 0
+    set fan2_min 1000
+#    set fan3_min 5600
+
+# Temperature sensor settings
+
+    label temp1 "CPU Tmp"
+    label temp2 "M/B Tmp"
+    label temp3 "NB     "
+
+# BioStar N68S+ BIOS doesn't use 'temp2' and 'temp3'.
+
+    ignore temp2
+    ignore temp3
+
+# Only set tempX_type if you have PC Health [disabled]
+# in your BIOS???? Generally, the kernel {lmsensors} will
+# correctly detect individual temperature sensor type and
+# set values accordingly.
+# 2 = thermistor; 3 = thermal diode; 0 = unused
+
+#    set temp1_type 2
+#    set temp2_type 2
+#    set temp3_type 3
+
+# Set your temparature max values. Warning: If your values here
+# are set higher than the values set in your BIOS, then you may
+# shutdown at a lower temperature than you think. It's probably
+# best to assume that shutdown will occur at the lowest setting
+# whenever the value here and the BIOS are different.
+
+   set temp1_max  50
+   set temp1_min  10
+#   set temp2_max  50
+#   set temp2_min  10
+
+# The other possibility is that a value set here will always
+# override the BIOS. You may or may not want that behavior.
+

--- a/configs/DFI/CFX3200-M2-G-infinity.conf
+++ b/configs/DFI/CFX3200-M2-G-infinity.conf
@@ -1,0 +1,61 @@
+# lm_sensors configuration file for the CFX3200-M2/G infinity motherboard
+# 2007-07-06, George Multescu
+
+chip "it8716-*"
+
+# Voltages
+
+    label  in0  "VCore" #-->cpu voltage
+    label  in1  "VDDR"
+    label  in2  "+3.3V"    # VCC3
+    label  in3  "+5V"      # VCC
+    label  in4  "V_NBr"	   #--> notrh bridge voltage
+    label  in5  "+12V"
+    ignore in6
+    label  in7  "5VSB"     # VCCH
+    label  in8  "VBat"
+
+    compute in3  ((6.8/10)+1)*@ , @/((6.8/10)+1)
+    compute in5  ((30/10)+1.02)*@  , @/((30/10)+1.02) #-->not sure about this one, check this value(+12v) against bios
+    compute in7  ((6.8/10)+1)*@ , @/((6.8/10)+1)
+
+# If vid (nominal CPU voltage) isn't correct, hardcode the correct value
+# instead.
+#    set in0_min  vid * 0.95
+#    set in0_max  vid * 1.05
+#    set in1_min  1.8 * 0.95
+#    set in1_max  1.8 * 1.05
+#    set in2_min  3.3 * 0.95
+#    set in2_max  3.3 * 1.05
+#    set in3_min    5 * 0.95
+#    set in3_max    5 * 1.05
+     set in4_min 1.18 * 0.95
+     set in4_max 1.18 * 1.05
+     set in5_max   12 * 1.05
+     set in5_min   12 * 0.95
+#    set in6_max   -5 * 0.95
+#    set in6_min   -5 * 1.05
+#    set in7_min    5 * 0.95
+#    set in7_max    5 * 1.05
+# The chip does not support in8 min/max
+
+# Temperatures
+
+
+label  temp1  "System Temp"
+label  temp2  "CPU Temp"
+label  temp3  "ChipsetTemp"
+
+#   set temp1_over  60
+#   set temp1_low   10
+#   set temp2_over  50
+#   set temp2_low   10
+
+# Fans
+
+label  fan1 "Chipset Fan"
+label  fan2 "CPU Fan"
+label fan3 "System fan"
+
+#   set fan1_min 2000
+#   set fan2_min 2000

--- a/configs/DFI/EL620-C.conf
+++ b/configs/DFI/EL620-C.conf
@@ -1,0 +1,82 @@
+# lm_sensors configuration file for DFI Itox EL620-C industrial motherboard
+# 2012-06-20, Paul Crawford <psc@sat.dundee.ac.uk>
+# Based on feedback from DFI and the schematic sheet 15 of 24, revision A1, 28 October 2011
+
+# Winbond W83627DHG configuration for EL620-C
+chip "w83627dhg-*"
+
+    label in0 "VCore"
+    label in1 "+5V"
+    label in2 "AVCC"
+    label in3 "+3.3V"
+    label in4 "+1.1V"
+    label in5 "Vmemory"
+    label in6 "+12V"
+    label in7 "Vstandby"
+    label in8 "VBAT"
+    
+# +12V and +5V use dividers from schematic
+    compute in1 @*(1+(30.1/10)),  @/(1+(30.1/10))
+    compute in6 @*(1+(60.4/10)),  @/(1+(60.4/10))
+
+# We need to set voltage limits.
+    set in0_min   0.80
+    set in0_max   1.55
+
+    set in1_min   5.0*0.95
+    set in1_max   5.0*1.05
+
+    set in2_min   3.3*0.95
+    set in2_max   3.3*1.05
+
+    set in3_min   3.3*0.95
+    set in3_max   3.3*1.05
+
+    set in4_min   1.1*0.95
+    set in4_max   1.1*1.05
+
+# DDR3 voltage range
+    set in5_min   1.30
+    set in5_max   1.58
+
+# Original ATX spec was +/-10% on +12V, but recent ATX12V version 2.2 spec is 5% (still 10% on unmonitored -12V)
+    set in6_min   12.0*0.95
+    set in6_max   12.0*1.05
+
+    set in7_min   3.3*0.95
+    set in7_max   3.3*1.05
+
+# Battery voltage, assume CR2032 Lithium-Manganese Dioxide Battery.
+# This actually seems not to be needed as hard-coded?
+    set in8_min   2.7
+    set in8_max   3.3
+
+# Fans
+   label fan1		"System Fan"
+   label fan2		"CPU Fan"
+   label fan3		"2nd Fan"
+   ignore fan4
+   ignore fan5
+   
+# Fan minimums, disable fan1 & fan3 as a case fan is not always connected
+  set fan1_min    0
+  set fan2_min    500
+  set fan3_min    0  
+
+# Temperatures. Can we assume temp2 limit for CPU is set by BIOS?
+
+   label temp1     "System Temp"
+   label temp2     "CPU Temp"
+   label temp3     "NB Temp"
+
+   set temp1_max       65
+   set temp1_max_hyst  55
+
+   set temp3_max       65
+   set temp3_max_hyst  55
+
+# Not sure what this is, always reported 0.000 and the VID0-VID7 pins are not connected on schematic.
+   ignore cpu0_vid
+	
+# From the Intel CPU itself? Seems not to need any special configuration.
+#chip "coretemp-*"

--- a/configs/DFI/Lanparty_MI_P55-T36.conf
+++ b/configs/DFI/Lanparty_MI_P55-T36.conf
@@ -1,0 +1,88 @@
+# lm_sensors configuration file for the board
+# DFI LP MI P55-T36
+# (The above name is reported by sensors-detect -A rev. 5818)
+# 2010-06-06, Lars Kr. Lundin
+# 2010-06-27, in3, in4 and in7 configuration added by Jean Delvare
+
+chip "it8720-*"
+# (sensors-detect -A: Found `ITE IT8720F Super IO Sensors')
+
+# Voltages
+
+# All these voltages match those listed in the BIOS:
+
+label in0 "Vcore"
+label in1 "Vtt"
+label in2 "+3.30V"
+label in3 "+5V"
+label in4 "+12V"
+label in5 "CPU PLL"
+label in6 "DRAM Voltage"
+label in7 "5VSB"
+
+compute  in3  @ * (6.8/10+1), @ / (6.8/10+1)
+compute  in4  @ *  (30/10+1), @ /  (30/10+1)
+compute  in7  @ * (6.8/10+1), @ / (6.8/10+1)
+
+# Temperatures
+
+# (sensors-detect -A finds NVIDIA i2c adapter i2c-[012345]
+#  with clients found for i2c-1 and i2c-5.
+#  The GPU temperature sensor is however not detected).
+
+label  temp1  "PCH Temp"
+label  temp2  "PWM Temp"
+label  temp3  "CPU Temp"
+
+# Default sensors output for temp3 is "disabled" and a too low temp shown.
+
+# From intel.com:
+# Digital Thermal Sensor (DTS)	Provides for more efficient processor and platform thermal control, improving system acoustics. The DTS continuously measures the temperature at each processing core. The ability to continuously measure and detect variations in processor temperature enables system fans to spin only as fast as needed to cool the system. The combination of these technologies can result in significantly lower noise emissions from the PC.
+
+# True Shown
+# 18    4
+
+# Correct the CPU temperature (at least at 18C):
+compute temp3 14+@, @-14
+
+# With the above correction the CPU temperature looks meaningful
+# and well correlated with the PWM temperature for varying CPU loads
+# and CPU fan speeds.
+# However the CPU temperature sensor responds to changes in the
+# CPU load almost instantaneously.
+
+# The sensor type for the DTS sensor currently comes out as: disabled
+# Don't know what sensor type to use for DTS sensor, so leave the default
+# set temp3_type 0
+
+# Fans
+
+ignore fan1
+
+# The BIOS labels the PWM (Pulse Width Modulated) fan "CPU fan".
+# The BIOS labels the other, non-PWM fan "PWM fan". This may be 
+# because this second fan is intended to cool the mainboards
+# MOSFET PWMs.
+label  fan2 "PWM fan"
+label  fan3 "CPU fan"
+
+# Example sensors output (CPU busy):
+
+# it8720-isa-0a10
+# Adapter: ISA adapter
+# Vcore:        +1.12 V  (min =  +0.00 V, max =  +4.08 V)   
+# Vtt:          +1.15 V  (min =  +0.00 V, max =  +4.08 V)   
+# +3.30V:       +3.26 V  (min =  +0.00 V, max =  +4.08 V)   
+# +5V:          +4.87 V  (min =  +0.00 V, max =  +6.85 V)   
+# +12V:        +11.71 V  (min =  +0.00 V, max = +16.32 V)   
+# CPU PLL:      +1.81 V  (min =  +0.00 V, max =  +4.08 V)   
+# DRAM Voltage: +1.65 V  (min =  +0.00 V, max =  +4.08 V)   
+# 5VSB:         +4.87 V  (min =  +0.00 V, max =  +6.85 V)   
+# Vbat:         +3.38 V
+# PWM fan:     4560 RPM  (min =    0 RPM)
+# CPU fan:      602 RPM  (min =    0 RPM)
+# PCH Temp:     +54.0°C  (low  =  -1.0°C, high = +127.0°C)  sensor = thermistor
+# PWM Temp:     +59.0°C  (low  =  -1.0°C, high = +127.0°C)  sensor = thermistor
+# CPU Temp:     +58.0°C  (low  = +13.0°C, high = +141.0°C)  sensor = disabled
+# cpu0_vid:    +1.300 V
+# 

--- a/configs/Epox/M1697.conf
+++ b/configs/Epox/M1697.conf
@@ -1,0 +1,39 @@
+# lm_sensors configuration file for the Epox EP-9U1697 GLI motherboard
+# 2007-07-06, Hans de Goede <j.w.r.degoede@hhs.nl>
+# Comments welcome!
+
+# Notice that the Epox ep1308 chip on the board in reality is a Fintek f71883fg
+
+chip "f71882fg-*"
+
+# Temperature
+    label temp1       "CPU"
+    label temp2       "System"
+    ignore temp3
+
+# Fans
+    label fan1        "CPU"
+    ignore fan2
+    ignore fan3
+    ignore fan4
+
+# Voltage
+    label in0         "3.3V"
+    label in1         "Vcore"
+    label in2         "Vdimm"
+    label in3         "Vchip"
+    label in4         "+5V"
+    label in5         "12V"
+    label in6         "5VSB"
+    label in7         "3VSB"
+    label in8         "Batery"
+
+# never change the in0, in7 and in8 compute, these are hardwired in the chip!
+    compute in0       (@ * 2), (@ / 2) 
+    compute in2       (@ * 2), (@ / 2)
+    compute in3       (@ * 2), (@ / 2)
+    compute in4       (@ * 5.25), (@ / 5.25)
+    compute in5       (@ * 12.83), (@ / 12.83)
+    compute in6       (@ * 5.25), (@ / 5.25)
+    compute in7       (@ * 2), (@ / 2)
+    compute in8       (@ * 2), (@ / 2)

--- a/configs/Epox/MF4-Ultra3.conf
+++ b/configs/Epox/MF4-Ultra3.conf
@@ -1,0 +1,48 @@
+# lm_sensors configuration file for the Epox MF4 Ultra3 motherboard
+# 2007-08-14, Hans de Goede <j.w.r.degoede@hhs.nl>
+# Comments welcome!
+
+# Notice that the Epox ep1308 chip on the board in reality is a Fintek f71883fg
+
+chip "k8temp-*"
+
+   label temp1 "Core0 Temp"
+   label temp2 "Core0 Temp"
+   label temp3 "Core1 Temp"
+   label temp4 "Core1 Temp"
+
+
+chip "f71882fg-*"
+
+# Temperature
+    label temp1       "CPU"
+    label temp2       "System"
+    ignore temp3
+
+# Fans
+    label fan1        "CPU"
+    label fan2        "System"
+    label fan3        "Power"
+    label fan4        "Aux"
+
+# Voltage
+    label in0         "3.3V"
+    label in1         "+5V"
+    label in2         "Vdimm"
+    label in3         "5VSB"
+    label in4         "12V"
+    label in5         "Vchip"
+    label in6         "Vcore"
+    label in7         "3VSB"
+    label in8         "Battery"
+
+# never change the in0, in7 and in8 compute, these are hardwired in the chip!
+    compute in0       (@ * 2), (@ / 2) 
+    compute in1       (@ * 5.25), (@ / 5.25)
+    compute in2       (@ * 2.5), (@ / 2.5)
+    compute in3       (@ * 5.25), (@ / 5.25)
+    compute in4       (@ * 11), (@ / 11)
+    compute in5       (@ * 1.5), (@ / 1.5)
+    compute in6       (@ * 1.5), (@ / 1.5)
+    compute in7       (@ * 2), (@ / 2)
+    compute in8       (@ * 2), (@ / 2)

--- a/configs/Evga/x58-SLI.conf
+++ b/configs/Evga/x58-SLI.conf
@@ -1,0 +1,37 @@
+# I have changed it for Evga x58 SLI board. -devsk 06-11-2009
+#
+chip "f71882fg-*"
+
+# Temperature
+    label temp1       "CPU"
+    label temp2       "VREG"
+    label temp3       "System"
+    #ignore temp3
+
+# Fans
+    label fan1        "CPU"
+    label fan2        "Power"
+    label fan3        "Chassis"
+    label fan4        "Aux"
+
+# Voltage
+    label in0         "3.3V"
+    label in1         "Vcore"
+    label in2         "Vdimm"
+    label in3         "Vtt"
+    label in4         "NB"
+    label in5         "+5V"
+    label in6         "+12V"
+    label in7         "3VSB"
+    label in8         "Battery"
+
+# never change the in0, in7 and in8 compute, these are hardwired in the chip!
+    compute in0       (@ * 2), (@ / 2)
+    compute in1       (@ * 1.47), (@ / 1.47)
+    compute in2       (@ * 1.45), (@ / 1.45)
+    compute in3       (@ * 1.241), (@ / 1.241)
+    compute in4       (@ * 1.241), (@ / 1.241)
+    compute in5       (@ * 5.25), (@ / 5.25)
+    compute in6       (@ * 9.23), (@ / 9.23)
+    compute in7       (@ * 2), (@ / 2)
+    compute in8       (@ * 2), (@ / 2)

--- a/configs/Foxconn/A7GM-S_2.0.conf
+++ b/configs/Foxconn/A7GM-S_2.0.conf
@@ -1,0 +1,41 @@
+# Configuration file contributed by Göran Uddeborg.
+
+
+chip "it8716-*"
+
+     label  in0 "CPU core"
+     label  in1 "DRAM voltage"
+     label  in2 "+3.3V"
+     # +5V
+     label  in4 "+12V"
+     label  in5 "+1.1V"
+     ignore in6
+     ignore in7
+     label  in8 Vbat
+
+     compute in3  @ * (1 + 6.8 / 10), @ / (1 + 6.8 / 10)
+     compute in4  @ * 4, @ / 4
+
+     label  fan1 "CPU fan"
+     label  fan2 "Chassis fan"
+     ignore fan3
+
+     label  temp1 "CPU temp"
+     label  temp2 "System temp"
+     ignore temp3
+
+     # Min and max for Athlon II X2 245e
+     set in0_min  0.875
+     set in0_max  1.4
+     # JEDEC standard for DDR2
+     set in1_min  1.7
+     set in1_max  1.9
+     # 5 % tolerance on the remaining measurements
+     set in2_min  3.3   * 0.95
+     set in2_max  3.3   * 1.05
+     set in3_min  5.0   * 0.95
+     set in3_max  5.0   * 1.05
+     set in4_min 12.0   * 0.95
+     set in4_max 12.0   * 1.05
+     set in5_min  1.1   * 0.95
+     set in5_max  1.1   * 1.05

--- a/configs/FujitsuTechnologySolutions/D2312_(A1,_A2,_C1,_C2).conf
+++ b/configs/FujitsuTechnologySolutions/D2312_(A1,_A2,_C1,_C2).conf
@@ -1,0 +1,24 @@
+# Fujitsu Technology Solutions Fujitsu D2312 (A1, A2, C1, C2), "Hades"-Chip
+# Contributed by Thilo Cestonaro <thilo.cestonaro@ts.fujitsu.com>
+
+chip "fschds-*"
+
+
+# Temperatures
+    label temp1 "CPU Temp"
+    label temp2 "Super I/O Temp"
+    label temp3 "System Temp"
+    ignore temp4
+    ignore temp5
+
+# Fans
+    label fan1 "PSU Fan"
+    label fan2 "CPU Fan"
+    label fan3 "System FAN2"
+    label fan4 "System FAN3"
+    label fan5 "System FAN4"
+
+# Voltages
+    label in0 "+12V"
+    label in1 "+5V"
+    label in2 "Vbat"

--- a/configs/FujitsuTechnologySolutions/D2314_(A1,_A2).conf
+++ b/configs/FujitsuTechnologySolutions/D2314_(A1,_A2).conf
@@ -1,0 +1,24 @@
+# Fujitsu Technology Solutions Fujitsu D2314 (A1, A2), "Hades"-Chip
+# Contributed by Thilo Cestonaro <thilo.cestonaro@ts.fujitsu.com>
+
+chip "fschds-*"
+
+
+# Temperatures
+    label temp1 "CPU Temp"
+    label temp2 "Super I/O Temp"
+    label temp3 "System Temp"
+    ignore temp4
+    ignore temp5
+
+# Fans
+    label fan1 "PSU Fan"
+    label fan2 "CPU Fan"
+    label fan3 "System FAN2"
+    label fan4 "System FAN3"
+    label fan5 "System FAN4"
+
+# Voltages
+    label in0 "+12V"
+    label in1 "+5V"
+    label in2 "Vbat"

--- a/configs/FujitsuTechnologySolutions/D2317_(A1,_A2).conf
+++ b/configs/FujitsuTechnologySolutions/D2317_(A1,_A2).conf
@@ -1,0 +1,24 @@
+# Fujitsu Technology Solutions D2317 (A1, A2), "Hades"-Chip
+# Contributed by Thilo Cestonaro <thilo.cestonaro@ts.fujitsu.com>
+
+chip "fschds-*"
+
+
+# Temperatures
+    label temp1 "CPU Temp"
+    label temp2 "Super I/O Temp"
+    label temp3 "System Temp"
+    ignore temp4
+    ignore temp5
+
+# Fans
+    label fan1 "PSU Fan"
+    label fan2 "CPU Fan"
+    label fan3 "System FAN2"
+    label fan4 "System FAN3"
+    label fan5 "System FAN4"
+
+# Voltages
+    label in0 "+12V"
+    label in1 "+5V"
+    label in2 "Vbat"

--- a/configs/FujitsuTechnologySolutions/D2344_(A1,_A2).conf
+++ b/configs/FujitsuTechnologySolutions/D2344_(A1,_A2).conf
@@ -1,0 +1,24 @@
+# Fujitsu Technology Solutions D2344 (A1, A2), "Hades"-Chip
+# Contributed by Thilo Cestonaro <thilo.cestonaro@ts.fujitsu.com>
+
+chip "fschds-*"
+
+
+# Temperatures
+    label temp1 "CPU Temp"
+    label temp2 "Super I/O Temp"
+    label temp3 "System Temp"
+    ignore temp4
+    ignore temp5
+
+# Fans
+    label fan1 "PSU Fan"
+    label fan2 "CPU Fan"
+    label fan3 "System FAN2"
+    label fan4 "System FAN3"
+    label fan5 "System FAN4"
+
+# Voltages
+    label in0 "+12V"
+    label in1 "+5V"
+    label in2 "Vbat"

--- a/configs/FujitsuTechnologySolutions/D2348_(A1,_A2).conf
+++ b/configs/FujitsuTechnologySolutions/D2348_(A1,_A2).conf
@@ -1,0 +1,24 @@
+# Fujitsu Technology Solutions D2348 (A1, A2), "Hades"-Chip
+# Contributed by Thilo Cestonaro <thilo.cestonaro@ts.fujitsu.com>
+
+chip "fschds-*"
+
+
+# Temperatures
+    label temp1 "CPU Temp"
+    label temp2 "Super I/O Temp"
+    label temp3 "System Temp"
+    ignore temp4
+    ignore temp5
+
+# Fans
+    label fan1 "PSU Fan"
+    label fan2 "CPU Fan"
+    label fan3 "System FAN2"
+    label fan4 "System FAN3"
+    label fan5 "System FAN4"
+
+# Voltages
+    label in0 "+12V"
+    label in1 "+5V"
+    label in2 "Vbat"

--- a/configs/FujitsuTechnologySolutions/D2364_(A1,_A2).conf
+++ b/configs/FujitsuTechnologySolutions/D2364_(A1,_A2).conf
@@ -1,0 +1,24 @@
+# Fujitsu Technology Solutions D2364 (A1, A2), "Hades"-Chip
+# Contributed by Thilo Cestonaro <thilo.cestonaro@ts.fujitsu.com>
+
+chip "fschds-*"
+
+
+# Temperatures
+    label temp1 "CPU Temp"
+    label temp2 "Super I/O Temp"
+    label temp3 "System Temp"
+    ignore temp4
+    ignore temp5
+
+# Fans
+    label fan1 "PSU Fan"
+    label fan2 "CPU Fan"
+    label fan3 "System FAN2"
+    label fan4 "System FAN3"
+    label fan5 "System FAN4"
+
+# Voltages
+    label in0 "+12V"
+    label in1 "+5V"
+    label in2 "Vbat"

--- a/configs/FujitsuTechnologySolutions/D2438_(A1,_A2).conf
+++ b/configs/FujitsuTechnologySolutions/D2438_(A1,_A2).conf
@@ -1,0 +1,24 @@
+# Fujitsu Technology Solutions D2438 (A1, A2), "Hades"-Chip
+# Contributed by Thilo Cestonaro <thilo.cestonaro@ts.fujitsu.com>
+
+chip "fschds-*"
+
+
+# Temperatures
+    label temp1 "CPU Temp"
+    label temp2 "Super I/O Temp"
+    label temp3 "System Temp"
+    ignore temp4
+    ignore temp5
+
+# Fans
+    label fan1 "PSU Fan"
+    label fan2 "CPU Fan"
+    label fan3 "System FAN2"
+    label fan4 "System FAN3"
+    label fan5 "System FAN4"
+
+# Voltages
+    label in0 "+12V"
+    label in1 "+5V"
+    label in2 "Vbat"

--- a/configs/FujitsuTechnologySolutions/D2584_(A1,_A5).conf
+++ b/configs/FujitsuTechnologySolutions/D2584_(A1,_A5).conf
@@ -1,0 +1,24 @@
+# Fujitsu Technology Solutions D2584 (A1, A5), "Hades"-Chip
+# Contributed by Thilo Cestonaro <thilo.cestonaro@ts.fujitsu.com>
+
+chip "fschds-*"
+
+
+# Temperatures
+    label temp1 "CPU Temp"
+    label temp2 "Super I/O Temp"
+    label temp3 "System Temp"
+    ignore temp4
+    ignore temp5
+
+# Fans
+    label fan1 "PSU Fan"
+    label fan2 "CPU Fan"
+    label fan3 "System FAN2"
+    label fan4 "System FAN3"
+    label fan5 "System FAN4"
+
+# Voltages
+    label in0 "+12V"
+    label in1 "+5V"
+    label in2 "Vbat"

--- a/configs/FujitsuTechnologySolutions/D2587A1.conf
+++ b/configs/FujitsuTechnologySolutions/D2587A1.conf
@@ -1,0 +1,24 @@
+# Fujitsu Technology Solutions D2587A1, "Hades"-Chip
+# Contributed by Thilo Cestonaro <thilo.cestonaro@ts.fujitsu.com>
+
+chip "fschds-*"
+
+
+# Temperatures
+    label temp1 "CPU Temp"
+    label temp2 "Super I/O Temp"
+    label temp3 "System Temp"
+    ignore temp4
+    ignore temp5
+
+# Fans
+    label fan1 "PSU Fan"
+    label fan2 "CPU Fan"
+    label fan3 "System FAN2"
+    label fan4 "System FAN3"
+    label fan5 "System FAN4"
+
+# Voltages
+    label in0 "+12V"
+    label in1 "+5V"
+    label in2 "Vbat"

--- a/configs/FujitsuTechnologySolutions/D2598A1.conf
+++ b/configs/FujitsuTechnologySolutions/D2598A1.conf
@@ -1,0 +1,24 @@
+# Fujitsu Technology Solutions D2598A1, "Hades"-Chip
+# Contributed by Thilo Cestonaro <thilo.cestonaro@ts.fujitsu.com>
+
+chip "fschds-*"
+
+
+# Temperatures
+    label temp1 "CPU Temp"
+    label temp2 "Super I/O Temp"
+    label temp3 "System Temp"
+    ignore temp4
+    ignore temp5
+
+# Fans
+    label fan1 "PSU Fan"
+    label fan2 "CPU Fan"
+    label fan3 "System FAN2"
+    label fan4 "System FAN3"
+    label fan5 "System FAN4"
+
+# Voltages
+    label in0 "+12V"
+    label in1 "+5V"
+    label in2 "Vbat"

--- a/configs/FujitsuTechnologySolutions/D2608_(A1,_K1).conf
+++ b/configs/FujitsuTechnologySolutions/D2608_(A1,_K1).conf
@@ -1,0 +1,24 @@
+# Fujitsu Technology Solutions D2608 (A1, K1), "Hades"-Chip
+# Contributed by Thilo Cestonaro <thilo.cestonaro@ts.fujitsu.com>
+
+chip "fschds-*"
+
+
+# Temperatures
+    label temp1 "CPU Temp"
+    label temp2 "Super I/O Temp"
+    label temp3 "System Temp"
+    ignore temp4
+    ignore temp5
+
+# Fans
+    label fan1 "PSU Fan"
+    label fan2 "CPU Fan"
+    label fan3 "System FAN2"
+    label fan4 "System FAN3"
+    label fan5 "System FAN4"
+
+# Voltages
+    label in0 "+12V"
+    label in1 "+5V"
+    label in2 "Vbat"

--- a/configs/FujitsuTechnologySolutions/D2618_(A1,_B1,_C1).conf
+++ b/configs/FujitsuTechnologySolutions/D2618_(A1,_B1,_C1).conf
@@ -1,0 +1,26 @@
+# Fujitsu Technology Solutions D2618 (A1, B1, C1), "Syleus"-Chip
+# Contributed by Thilo Cestonaro <thilo.cestonaro@ts.fujitsu.com>
+
+chip "fscsyl-*"
+
+# Temperatures
+    label temp1 "CPU Temp"
+    ignore temp2
+    ignore temp3
+    label temp4 "Super I/O Temp"
+    label temp5 "Northbridge Temp"
+
+# Fans
+    label fan1 "CPU Fan"
+    label fan2 "System FAN2"
+    label fan3 "System FAN3"
+    label fan4 "System FAN4"
+    label fan7 "PSU Fan"
+
+# Voltages
+    label in0 "+12V"
+    label in1 "+5V"
+    label in2 "Vbat"
+    ignore in4
+    label in3 "+3.3V"
+    label in5 "+3.3V-Aux"

--- a/configs/FujitsuTechnologySolutions/D2628_(A1,_B1,_C1).conf
+++ b/configs/FujitsuTechnologySolutions/D2628_(A1,_B1,_C1).conf
@@ -1,0 +1,26 @@
+# Fujitsu Technology Solutions D2628 (A1, B1, C1), "Syleus"-Chip
+# Contributed by Thilo Cestonaro <thilo.cestonaro@ts.fujitsu.com>
+
+chip "fscsyl-*"
+
+# Temperatures
+    label temp1 "CPU Temp"
+    ignore temp2
+    ignore temp3
+    label temp4 "Super I/O Temp"
+    label temp5 "Northbridge Temp"
+
+# Fans
+    label fan1 "CPU Fan"
+    label fan2 "System FAN2"
+    label fan3 "System FAN3"
+    label fan4 "System FAN4"
+    label fan7 "PSU Fan"
+
+# Voltages
+    label in0 "+12V"
+    label in1 "+5V"
+    label in2 "Vbat"
+    ignore in4
+    label in3 "+3.3V"
+    label in5 "+3.3V-Aux"

--- a/configs/FujitsuTechnologySolutions/D2679A1.conf
+++ b/configs/FujitsuTechnologySolutions/D2679A1.conf
@@ -1,0 +1,24 @@
+# Fujitsu Technology Solutions D2679A1, "Hades"-Chip
+# Contributed by Thilo Cestonaro <thilo.cestonaro@ts.fujitsu.com>
+
+chip "fschds-*"
+
+
+# Temperatures
+    label temp1 "CPU Temp"
+    label temp2 "Super I/O Temp"
+    label temp3 "System Temp"
+    ignore temp4
+    ignore temp5
+
+# Fans
+    label fan1 "PSU Fan"
+    label fan2 "CPU Fan"
+    label fan3 "System FAN2"
+    label fan4 "System FAN3"
+    label fan5 "System FAN4"
+
+# Voltages
+    label in0 "+12V"
+    label in1 "+5V"
+    label in2 "Vbat"

--- a/configs/FujitsuTechnologySolutions/D2778_(A1,_B1,_C1,_X1,_Y1).conf
+++ b/configs/FujitsuTechnologySolutions/D2778_(A1,_B1,_C1,_X1,_Y1).conf
@@ -1,0 +1,26 @@
+# Fujitsu Technology Solutions D2778 (A1, B1 ,C1, X1, Y1), "Syleus"-Chip
+# Contributed by Thilo Cestonaro <thilo.cestonaro@ts.fujitsu.com>
+
+chip "fscsyl-*"
+
+# Temperatures
+    label temp1 "CPU Temp"
+    ignore temp2
+    ignore temp3
+    label temp4 "Super I/O Temp"
+    label temp5 "Northbridge Temp"
+
+# Fans
+    label fan1 "CPU Fan"
+    label fan2 "System FAN2"
+    label fan3 "System FAN3"
+    label fan4 "System FAN4"
+    label fan7 "PSU Fan"
+
+# Voltages
+    label in0 "+12V"
+    label in1 "+5V"
+    label in2 "Vbat"
+    ignore in4
+    label in3 "+3.3V"
+    label in5 "+3.3V-Aux"

--- a/configs/FujitsuTechnologySolutions/D2812_(A1,_A2).conf
+++ b/configs/FujitsuTechnologySolutions/D2812_(A1,_A2).conf
@@ -1,0 +1,26 @@
+# Fujitsu Technology Solutions D2812 (A1, A2), "Syleus"-Chip
+# Contributed by Thilo Cestonaro <thilo.cestonaro@ts.fujitsu.com>
+
+chip "fscsyl-*"
+
+# Temperatures
+    label temp1 "CPU Temp"
+    ignore temp2
+    ignore temp3
+    label temp4 "Super I/O Temp"
+    label temp5 "Northbridge Temp"
+
+# Fans
+    label fan1 "CPU Fan"
+    label fan2 "System FAN2"
+    label fan3 "System FAN3"
+    label fan4 "System FAN4"
+    label fan7 "PSU Fan"
+
+# Voltages
+    label in0 "+12V"
+    label in1 "+5V"
+    label in2 "Vbat"
+    ignore in4
+    label in3 "+3.3V"
+    label in5 "+3.3V-Aux"

--- a/configs/FujitsuTechnologySolutions/D2817A1.conf
+++ b/configs/FujitsuTechnologySolutions/D2817A1.conf
@@ -1,0 +1,26 @@
+# Fujitsu Technology Solutions D2817A1, "Syleus"-Chip
+# Contributed by Thilo Cestonaro <thilo.cestonaro@ts.fujitsu.com>
+
+chip "fscsyl-*"
+
+# Temperatures
+    label temp1 "CPU Temp"
+    ignore temp2
+    ignore temp3
+    label temp4 "Super I/O Temp"
+    label temp5 "Northbridge Temp"
+
+# Fans
+    label fan1 "CPU Fan"
+    label fan2 "System FAN2"
+    label fan3 "System FAN3"
+    label fan4 "System FAN4"
+    label fan7 "PSU Fan"
+
+# Voltages
+    label in0 "+12V"
+    label in1 "+5V"
+    label in2 "Vbat"
+    ignore in4
+    label in3 "+3.3V"
+    label in5 "+3.3V-Aux"

--- a/configs/FujitsuTechnologySolutions/D2828_(A1,_A2).conf
+++ b/configs/FujitsuTechnologySolutions/D2828_(A1,_A2).conf
@@ -1,0 +1,26 @@
+# Fujitsu Technology Solutions D2828 (A1, A2), "Syleus"-Chip
+# Contributed by Thilo Cestonaro <thilo.cestonaro@ts.fujitsu.com>
+
+chip "fscsyl-*"
+
+# Temperatures
+    label temp1 "CPU Temp"
+    ignore temp2
+    ignore temp3
+    label temp4 "Super I/O Temp"
+    label temp5 "Northbridge Temp"
+
+# Fans
+    label fan1 "CPU Fan"
+    label fan2 "System FAN2"
+    label fan3 "System FAN3"
+    label fan4 "System FAN4"
+    label fan7 "PSU Fan"
+
+# Voltages
+    label in0 "+12V"
+    label in1 "+5V"
+    label in2 "Vbat"
+    ignore in4
+    label in3 "+3.3V"
+    label in5 "+3.3V-Aux"

--- a/configs/FujitsuTechnologySolutions/D2831S1.conf
+++ b/configs/FujitsuTechnologySolutions/D2831S1.conf
@@ -1,0 +1,26 @@
+# Fujitsu Technology Solutions D2831S1, "Syleus"-Chip
+# Contributed by Thilo Cestonaro <thilo.cestonaro@ts.fujitsu.com>
+
+chip "fscsyl-*"
+
+# Temperatures
+    label temp1 "CPU Temp"
+    ignore temp2
+    ignore temp3
+    label temp4 "Super I/O Temp"
+    label temp5 "Northbridge Temp"
+
+# Fans
+    label fan1 "CPU Fan"
+    label fan2 "System FAN2"
+    label fan3 "System FAN3"
+    label fan4 "System FAN4"
+    label fan7 "PSU Fan"
+
+# Voltages
+    label in0 "+12V"
+    label in1 "+5V"
+    label in2 "Vbat"
+    ignore in4
+    label in3 "+3.3V"
+    label in5 "+3.3V-Aux"

--- a/configs/FujitsuTechnologySolutions/D2836S1.conf
+++ b/configs/FujitsuTechnologySolutions/D2836S1.conf
@@ -1,0 +1,26 @@
+# Fujitsu Technology Solutions D2836S1, "Syleus"-Chip
+# Contributed by Thilo Cestonaro <thilo.cestonaro@ts.fujitsu.com>
+
+chip "fscsyl-*"
+
+# Temperatures
+    label temp1 "CPU Temp"
+    ignore temp2
+    ignore temp3
+    label temp4 "Super I/O Temp"
+    label temp5 "Northbridge Temp"
+
+# Fans
+    label fan1 "CPU Fan"
+    label fan2 "System FAN2"
+    label fan3 "System FAN3"
+    label fan4 "System FAN4"
+    label fan7 "PSU Fan"
+
+# Voltages
+    label in0 "+12V"
+    label in1 "+5V"
+    label in2 "Vbat"
+    ignore in4
+    label in3 "+3.3V"
+    label in5 "+3.3V-Aux

--- a/configs/Gigabyte/B75-D3V.conf
+++ b/configs/Gigabyte/B75-D3V.conf
@@ -1,0 +1,107 @@
+# Configuration file contributed by Dominik Egert.
+
+
+# libsensors configuration file
+# -----------------------------
+#
+#  For the Gigabyte B75-D3V Rev: 1.2
+#
+#
+#
+
+	######################################
+	# VOLTAGES                           #
+	# These figures are from estimations #
+	# based on values provided in BIOS.  #
+	# This means that some of them may   #
+	# be mixed up.                       #
+	######################################
+
+
+##############################################
+chip "it8728-isa-0a30"
+
+########
+# Fans
+label fan1 "CPU-Fan"
+set fan1_min 1000
+
+label fan2 "System Fan 1"
+set fan2_min 450
+
+label fan3 "System Fan 2"
+set fan3_min 450
+
+label fan4 "System Fan 3"
+set fan4_min 450
+
+ignore fan5 #"Chassis Fan" # It is not connected, no pinout available.
+
+
+################
+# Temperatures
+label temp1 "System Temperature"
+set temp1_min 10
+set temp1_max 60
+
+ignore temp2 
+#label temp2 "Unknown" # Does not seem to give sensible data (Always shows 25)
+
+label temp3 "Chipset Temperature"
+set temp3_min 10
+set temp3_max 55
+
+
+############
+# Voltages
+label in0 "Vtt"
+set in0_min 1.020
+set in0_max 1.080
+
+label in1 "+3.3V"
+set in1_min 3.3 * 0.95
+set in1_max 3.3 * 1.05
+compute in1 1.635*@,@/1.635
+
+label in2 "+12V"
+set in2_min 12.0 * 0.95
+set in2_max 12.0 * 1.05
+compute in2 6.0*@,@/6.0
+
+label in3 "+5V"
+set in3_min 5.0 * 0.95
+set in3_max 5.0 * 1.05
+compute in3 2.5*@,@/2.5
+
+label in4 "Vaxg IGD"
+set in4_min 0.800
+set in4_max 1.000
+
+label in5 "CPU Vcore"
+set in5_min 0.750
+set in5_max 1.150
+
+label in6 "Dram Voltage"
+set in6_min 1.450
+set in6_max 1.550
+
+label in7 "3.3 VSB"
+set in7_min 3.3 * 0.95
+set in7_max 3.3 * 1.05
+
+label in8 "Vbat"
+
+# Other sensor readings
+label intrusion0 "Chassis Open"
+#set intrusion0_alarm 0
+
+
+##############################################
+chip "acpitz-virtual-0"
+
+ignore temp1
+#label temp1 "ACPI Thermal Zone 0 Temp1" # Shows always 27.8
+
+ignore temp2
+#label temp2 "ACPI Thermal Zone 0 Temp2" # Shows always 29.8
+

--- a/configs/Gigabyte/EX38-DS4.conf
+++ b/configs/Gigabyte/EX38-DS4.conf
@@ -1,0 +1,47 @@
+# Configuration file contributed by Marc Muehlfeld.
+
+
+chip "it8718-*"
+
+        # Voltages
+        label   in0 "CPU Vcore"
+        label   in1 "DDR"
+        label   in2 "+3.3V"
+        label   in3 "+5V"
+        ignore  in4
+        ignore  in5
+        ignore  in6
+        label   in7 "+12V"
+        label   in8 "VBat"
+
+        compute in3  @ * (6.8/10+1), @ / (6.8/10+1)
+        compute in7  @ * 3.963,      @ / 3.963
+
+        set in0_min  1.120 * 0.95
+        set in0_max  1.120 * 1.05
+        set in1_min  1.89  * 0.95
+        set in1_max  1.89  * 1.05
+        set in2_min  3.3   * 0.95
+        set in2_max  3.3   * 1.05
+        set in3_min  5     * 0.95
+        set in3_max  5     * 1.05
+        set in7_min 12     * 0.95
+        set in7_max 12     * 1.05
+
+
+        # Temperatures
+        label  temp1 "CPU temp"
+        label  temp2 "System temp"
+        ignore temp3
+        
+        set temp1_min 10
+        set temp1_max 65
+        set temp2_min 10
+        set temp2_max 55
+
+
+        # Fans
+        label  fan1 "CPU fan"
+        label  fan2 "Chassis fan"
+        label  fan3 "Sys fan 2"
+        label  fan4 "Sys fan 1"

--- a/configs/Gigabyte/G33-DS3R.conf
+++ b/configs/Gigabyte/G33-DS3R.conf
@@ -1,0 +1,63 @@
+# Configuration file contributed by Eduardo Diaz Rodriguez, based on earlier
+# work by Jean Delvare. This is basically the same as for the 965P DS3, except
+# that the G33 DS3R has a 3rd fan header.
+
+
+# lm_sensors configuration file for the Gigabyte G33 DS3R motherboard
+
+chip "it8718-*"
+
+### Voltages
+
+   label  in0  "Vcore"
+   label  in1  "Vram"    # "DDR18V" in BIOS
+   label  in2  "+3.3V"
+   label  in3  "+5V"     # Not in BIOS
+   ignore in4
+   ignore in5
+   ignore in6
+   label  in7  "+12V"
+   label  in8  "Vbat"    # Not in BIOS
+
+   # Vcore, Vram, +3.3V and Vbat are connected directly, so no compute
+   # line is needed for these. For +5V the chip is configured to use
+   # internal scaling. For +12V the default resistors seem to have been
+   # used.
+   compute  in3  @ * (6.8/10+1), @ / (6.8/10+1)
+   compute  in7  @ * ( 30/10+1), @ / ( 30/10+1)
+
+   # The BIOS won't set any limit for voltages.
+
+   set in0_min vid * 0.95
+   set in0_max vid * 1.05
+   set in1_min 1.8 * 0.95
+   set in1_max 1.8 * 1.05
+   set in2_min 3.3 * 0.95
+   set in2_max 3.3 * 1.05
+   set in3_min   5 * 0.95
+   set in3_max   5 * 1.05
+   set in7_min  12 * 0.95
+   set in7_max  12 * 1.05
+
+### Temperatures
+
+   label  temp1  "NBr Temp"
+   label  temp2  "CPU Temp"
+   ignore temp3
+
+   set sensor3 0
+
+   set temp1_low  10
+   set temp1_over 50
+   set temp2_low  10
+   set temp2_over 60
+
+### Fans
+
+   label  fan1  "CPU Fan"
+   label  fan2  "Case Fan"
+
+   # Adjust for your own fans
+   set fan1_min 1000
+   set fan2_min 4000
+

--- a/configs/Gigabyte/GA-770TA-UD3.conf
+++ b/configs/Gigabyte/GA-770TA-UD3.conf
@@ -1,0 +1,68 @@
+# Configuration file for the Gigabyte GA-770TA-UD3. 
+# Submitted by Ancoron Luciferis
+
+
+# libsensors3 configuration file for the Gigabyte GA-770TA-UD3
+
+chip "it8720-isa-*"
+### Voltages
+
+   # in5 is mysterious.
+
+   label  in0  "Vcore"
+   label  in1  "Vdram"   # "DDR3" in BIOS
+   label  in2  "+3.3V"
+   label  in3  "+5V"     # Not in BIOS
+   label  in4  "+12V"
+   ignore in5
+   ignore in6
+   label  in7  "5VSB"    # Not in BIOS
+   label  in8  "Vbat"    # Not in BIOS
+   ignore cpu0_vid
+
+   # Vcore, Vdram, +3.3V and Vbat are connected directly, so no compute
+   # line is needed for these. +5V and 5VSB are internal so we use the
+   # standard scaling factor. Scaling for +12V is apparently not standard,
+   # factor 3.963 is guessed from BIOS and EasyTune values (3.943 was
+   # another candidate.)
+   compute  in3  @ * (6.8/10+1), @ / (6.8/10+1)
+   compute  in4  @ * 3.963,      @ / 3.963
+   compute  in7  @ * (6.8/10+1), @ / (6.8/10+1)
+
+   # The BIOS won't set any limit for voltages.
+
+   set in0_min  0.825 * 0.95
+   set in0_max  1.425 * 1.05
+   set in1_min  1.5   * 0.95
+   set in1_max  1.5   * 1.05
+   set in2_min  3.3   * 0.95
+   set in2_max  3.3   * 1.05
+   set in3_min  5     * 0.95
+   set in3_max  5     * 1.05
+   set in4_min 12     * 0.95
+   set in4_max 12     * 1.05
+   set in7_min  5     * 0.95
+   set in7_max  5     * 1.05
+
+### Temperatures
+
+   # The BIOS only shows 2 temperature values:
+   # - temp1: the system temprature
+   # - temp2: the CPU temperature
+
+   label temp1 "SYS Temp"
+   label temp2 "CPU Casing Temp"
+   ignore temp3
+
+### Fans
+
+   label  fan1 "CPU Fan"
+   ignore fan2
+   ignore fan3
+   # ignore fan4 # doesn't exist on GA-770TA-UD3
+   ignore fan5
+
+   # Adjust for your own fans
+   set fan1_min 1000
+   # set fan3_min 3000
+

--- a/configs/Gigabyte/GA-790XTA-UD4.conf
+++ b/configs/Gigabyte/GA-790XTA-UD4.conf
@@ -1,0 +1,76 @@
+# Configuration file for the Gigabyte GA-790XTA-UD4.
+# Submitted by Ancoron Luciferis
+
+
+# libsensors3 configuration file for the Gigabyte GA-790XTA-UD4
+
+chip "it8720-isa-*"
+### Voltages
+
+   # in5 is mysterious.
+
+   label  in0  "Vcore"
+   label  in1  "Vdram"   # "DDR3" in BIOS
+   label  in2  "+3.3V"
+   label  in3  "+5V"     # Not in BIOS
+   label  in4  "+12V"
+   ignore in5
+   ignore in6
+   label  in7  "5VSB"    # Not in BIOS
+   label  in8  "Vbat"    # Not in BIOS
+   ignore cpu0_vid
+
+   # Vcore, Vdram, +3.3V and Vbat are connected directly, so no compute
+   # line is needed for these. +5V and 5VSB are internal so we use the
+   # standard scaling factor. Scaling for +12V is apparently not standard,
+   # factor 3.963 is guessed from BIOS and EasyTune values (3.943 was
+   # another candidate.)
+   compute  in3  @ * (6.8/10+1), @ / (6.8/10+1)
+   compute  in4  @ * 3.963,      @ / 3.963
+   compute  in7  @ * (6.8/10+1), @ / (6.8/10+1)
+
+   # The BIOS won't set any limit for voltages.
+
+   set in0_min  0.825 * 0.95
+   set in0_max  1.425 * 1.05
+   set in1_min  1.5   * 0.95
+   set in1_max  1.5   * 1.05
+   set in2_min  3.3   * 0.95
+   set in2_max  3.3   * 1.05
+   set in3_min  5     * 0.95
+   set in3_max  5     * 1.05
+   set in4_min 12     * 0.95
+   set in4_max 12     * 1.05
+   set in7_min  5     * 0.95
+   set in7_max  5     * 1.05
+
+### Temperatures
+
+   # The BIOS only shows 2 temperature values, so temp1 and temp3
+   # might not be actually both used, and I don't know which one
+   # is reported by the BIOS as the system temperature.
+
+   label temp1 "SYS Temp"
+   set   temp1_min 0
+   set   temp1_max 50 # Tropical ambient max plus a bit
+
+   label temp2  "CPU Casing Temp"
+   set   temp2_min 0
+   set   temp2_max 65 # BIOS "CPU Warning Temperature" - 5
+
+   label temp3 "NB Temp"
+   set   temp3_min 0
+   set   temp3_max 55 # BIOS "CPU Warning Temperature" - 15
+
+### Fans
+
+   label fan1 "CPU Fan"
+   ignore fan2
+   label fan3 "SYS Fan 2"
+   # ignore fan4 # doesn't exist on GA-790XTA-UD4
+   ignore fan5
+
+   # Adjust for your own fans
+   set fan1_min 300
+   set fan3_min 300
+

--- a/configs/Gigabyte/GA-870A-UD3.conf
+++ b/configs/Gigabyte/GA-870A-UD3.conf
@@ -1,0 +1,91 @@
+# Configuration file for the Gigabyte GA-870A-UD3,
+# contributed by Gary Myers and Zeke Fast.
+
+# libsensors3 configuration file for the Gigabyte GA-870A-UD3
+# 2011-06-16 Gary Myers
+# Updates welcome.
+
+# CPU sensor
+
+chip "k10temp-*"
+
+   label temp1 "CPU Temp (K10)" # Set for gnome-sensors-applet.
+				# See second CPU temp below.
+
+# Motherboard sensors
+
+chip "it8720-isa-*"
+
+### Voltages
+
+   label  in0  "Vcore"
+   label  in1  "DDR3 1.5V" # as labelled in the BIOS.
+   label  in2  "+3.3V"
+   label  in3  "+5V"     # Not shown in BIOS.
+   label  in4  "+12V"
+   ignore in5		 # Ambiguous - ignoring.
+   ignore in6		 # Ambiguous - ignoring.
+   label  in7  "5VSB"    # Not shown in BIOS.
+   label  in8  "Vbat"    # Not shown in BIOS.
+   ignore cpu0_vid
+
+   # "Vcore", "DDR3 1.5V", "+3.3V" and "Vbat" are connected directly, so no compute
+   # line is needed for these. +5V and 5VSB are internal so we use the
+   # standard scaling factor. Scaling for +12V is apparently not standard,
+   # factor 3.963 is guessed from BIOS and EasyTune values (3.943 was
+   # another candidate.)
+   compute  in3  @ * (6.8/10+1), @ / (6.8/10+1)
+   compute  in4  @ * 3.963,      @ / 3.963
+   compute  in7  @ * (6.8/10+1), @ / (6.8/10+1)
+
+   # The BIOS will not set any limit for voltages.
+
+   set in0_min  0.825 * 0.95
+   set in0_max  1.425 * 1.05
+   set in1_min  1.5   * 0.95
+   set in1_max  1.5   * 1.05
+   set in2_min  3.3   * 0.95
+   set in2_max  3.3   * 1.05
+   set in3_min  5     * 0.95
+   set in3_max  5     * 1.05
+   set in4_min 12     * 0.95
+   set in4_max 12     * 1.05
+   set in7_min  5     * 0.95
+   set in7_max  5     * 1.05
+
+### Temperatures
+
+   label temp1 "System Temp"
+   # This sensor appears to be around or inside the ITE8720F chip.
+   # The temperature drops if the chip and board area are cooled with
+   # freezer spray. This sensor may be over-reading!
+   # Adjustment applied to match internal case thermal sensor from my Antec P160.
+   compute temp1  (@ -20),  (@ + 20)
+   set   temp1_min 0
+   set   temp1_max 50 # Tropical ambient max plus a bit
+
+   label temp2  "CPU Temp"
+   # This sensor can show 2 degrees difference to the K10 sensor.
+   # The end user can choose which one they prefer.
+   set   temp2_min 0
+   set   temp2_max 70 # Set to match your BIOS "CPU Warning Temperature"
+
+   ignore temp3	# No idea what this sensor is for. It always shows
+		# +78 deg C regardless of BIOS settings.
+
+### Fans
+
+   # Label based on motherboard connectors.
+   label fan1 "CPU Fan"		# M/B label: CPU_FAN (4-pin - near ATX 12V)
+   label fan5 "Power Fan"	# M/B label: PWR_FAN (3-pin - near ATX)
+   label fan2 "System Fan 1"	# M/B label: SYS_FAN1 (4-pin - near F_PANEL)
+   label fan3 "System Fan 2"	# M/B label: SYS_FAN2 (3-pin - near SATA3_4)
+
+   # Minimum fan speeds.
+   # Comment/un-comment fan headers you are using if you want alarms.
+   set fan1_min 300	# CPU Fan
+   set fan5_min 300	# Power Fan
+   #set fan2_min 300	# System Fan 1
+   set fan3_min 300	# System Fan 2
+
+

--- a/configs/Gigabyte/GA-870A-USB3.conf
+++ b/configs/Gigabyte/GA-870A-USB3.conf
@@ -1,0 +1,90 @@
+# Configuration file for the Gigabyte GA-870A-USB3,
+# contributed by Gary Myers and Zeke Fast.
+
+
+# libsensors3 configuration file for the Gigabyte GA-870A-USB3
+# 2011-06-16 Gary Myers
+# Updates welcome.
+
+# CPU sensor
+
+chip "k10temp-*"
+
+   label temp1 "CPU Temp (K10)" # Set for gnome-sensors-applet.
+				# See second CPU temp below.
+
+# Motherboard sensors
+
+chip "it8720-isa-*"
+
+### Voltages
+
+   label  in0  "Vcore"
+   label  in1  "DDR3 1.5V" # as labelled in the BIOS.
+   label  in2  "+3.3V"
+   label  in3  "+5V"     # Not shown in BIOS.
+   label  in4  "+12V"
+   ignore in5		 # Ambiguous - ignoring.
+   ignore in6		 # Ambiguous - ignoring.
+   label  in7  "5VSB"    # Not shown in BIOS.
+   label  in8  "Vbat"    # Not shown in BIOS.
+   ignore cpu0_vid
+
+   # "Vcore", "DDR3 1.5V", "+3.3V" and "Vbat" are connected directly, so no compute
+   # line is needed for these. +5V and 5VSB are internal so we use the
+   # standard scaling factor. Scaling for +12V is apparently not standard,
+   # factor 3.963 is guessed from BIOS and EasyTune values (3.943 was
+   # another candidate.)
+   compute  in3  @ * (6.8/10+1), @ / (6.8/10+1)
+   compute  in4  @ * 3.963,      @ / 3.963
+   compute  in7  @ * (6.8/10+1), @ / (6.8/10+1)
+
+   # The BIOS will not set any limit for voltages.
+
+   set in0_min  0.825 * 0.95
+   set in0_max  1.425 * 1.05
+   set in1_min  1.5   * 0.95
+   set in1_max  1.5   * 1.05
+   set in2_min  3.3   * 0.95
+   set in2_max  3.3   * 1.05
+   set in3_min  5     * 0.95
+   set in3_max  5     * 1.05
+   set in4_min 12     * 0.95
+   set in4_max 12     * 1.05
+   set in7_min  5     * 0.95
+   set in7_max  5     * 1.05
+
+### Temperatures
+
+   label temp1 "System Temp"
+   # This sensor appears to be around or inside the ITE8720F chip.
+   # The temperature drops if the chip and board area are cooled with
+   # freezer spray. This sensor may be over-reading!
+   # Adjustment applied to match internal case thermal sensor from my Antec P160.
+   compute temp1  (@ -20),  (@ + 20)
+   set   temp1_min 0
+   set   temp1_max 50 # Tropical ambient max plus a bit
+
+   label temp2  "CPU Temp"
+   # This sensor can show 2 degrees difference to the K10 sensor.
+   # The end user can choose which one they prefer.
+   set   temp2_min 0
+   set   temp2_max 70 # Set to match your BIOS "CPU Warning Temperature"
+
+   ignore temp3	# No idea what this sensor is for. It always shows
+		# +78 deg C regardless of BIOS settings.
+
+### Fans
+
+   # Label based on motherboard connectors.
+   label fan1 "CPU Fan"		# M/B label: CPU_FAN (4-pin - near ATX 12V)
+   label fan5 "Power Fan"	# M/B label: PWR_FAN (3-pin - near ATX)
+   label fan2 "System Fan 1"	# M/B label: SYS_FAN1 (4-pin - near F_PANEL)
+   label fan3 "System Fan 2"	# M/B label: SYS_FAN2 (3-pin - near SATA3_4)
+
+   # Minimum fan speeds.
+   # Comment/un-comment fan headers you are using if you want alarms.
+   set fan1_min 300	# CPU Fan
+   set fan5_min 300	# Power Fan
+   #set fan2_min 300	# System Fan 1
+   set fan3_min 300	# System Fan 2

--- a/configs/Gigabyte/GA-945GCM-S2L.conf
+++ b/configs/Gigabyte/GA-945GCM-S2L.conf
@@ -1,0 +1,63 @@
+# Configuration file contributed by Ian Pangilinan.
+
+
+### Sensors configuration for Gigabyte GA-945GCM-S2L motherboard
+### 2014-02-21, ianp <snailbox88-dev -at- yahoo -dot- com>
+### Thanks to Jean Delvare
+### Comments are welcome.
+
+
+chip "it8718-*"
+
+### Voltages
+
+   label  in0  "Vcore"
+   label  in1  "Vram"    # "DDR18V" in BIOS
+   label  in2  "+3.3V"
+   ignore in3            # no +5V monitor, not used
+   label  in4  "+12V"
+   ignore in5            # these inputs
+   ignore in6            # are not used
+   ignore in7            # by the board
+
+   ### Scale +12V.
+
+   compute  in4  @*3.9633,  @/3.9633
+
+   ### Set in0 according to CPU VID voltage range.
+   ### Set min and max values according to preference.
+
+   set in0_min  0.850
+   set in0_max  1.362
+   set in1_min  1.8 * 0.95
+   set in1_max  1.8 * 1.05
+   set in2_min  3.3 * 0.95
+   set in2_max  3.3 * 1.05
+   set in4_min   12 * 0.95
+   set in4_max   12 * 1.05
+
+### Temperatures
+
+   ### Ignore temp1 and temp2 as those aren't used.
+
+   ignore temp1
+   ignore temp2
+   label  temp3  "CPU Temp"
+
+   ### Set according to CPU.
+
+   set temp3_min 10
+   set temp3_max 60
+
+### Fans
+
+   ### Ignore fan3 as it isn't used.
+
+   label  fan1  "CPU Fan"
+   label  fan2  "CHA Fan"
+   ignore fan3
+
+   ### Set according to preference.
+
+   set fan1_min 900
+   set fan2_min 0

--- a/configs/Gigabyte/GA-990FXA-UD3.conf
+++ b/configs/Gigabyte/GA-990FXA-UD3.conf
@@ -1,0 +1,70 @@
+# Configuration file contributed by Ki'Sak.
+
+
+# libsensors3 configuration file for the GA-990FXA-UD3 Rev. 1.1
+# This is strongly based on the Gigabyte GA-790XTA-UD4 sensors3.conf
+
+chip "it8720-isa-*"
+
+### Voltages
+
+   # in5 is mysterious. It is -12V in other uses of this chip, but unstable here
+   # -12V is in the ATX spec for ISA, which is used sparingly in modern hardware
+
+   label  in0  "Vcore"
+   label  in1  "Vdram"    # "DDR3" in BIOS
+   label  in2  "+3.3V"
+   label  in3  "+5V"      # Not in BIOS
+   label  in4  "+12V"
+   ignore in5             # -12V unused
+   ignore in6
+   label  in7  "5VSB"     # Not in BIOS
+   label  in8  "Vbat"     # Not in BIOS
+   ignore cpu0_vid
+
+### Fan labels as found on the motherboard
+
+   label  fan1 "CPU_FAN"  # controlled by temp3
+   label  fan2 "SYS_FAN1" # controlled by temp1
+   label  fan3 "SYS_FAN2"
+   label  fan4 "PWR_FAN"  # unregulated max speed
+
+   # Vcore, Vdram, +3.3V and Vbat are connected directly, so no compute
+   # line is needed for these. +5V and 5VSB are internal so we use the
+   # standard scaling factor. Scaling for +12V is apparently not standard,
+   # factor 3.963 is guessed from BIOS and EasyTune values (3.943 was
+   # another candidate.)
+   # These values have not been rechecked from the GA-790XTA-UD4
+   compute  in3  @ * (6.8/10+1), @ / (6.8/10+1)
+   compute  in4  @ * 3.963,      @ / 3.963
+   compute  in7  @ * (6.8/10+1), @ / (6.8/10+1)
+
+   # The BIOS won't set any limit for voltages.
+
+   set in0_min  0.825 * 0.95
+   set in0_max  1.425 * 1.05
+   set in1_min  1.5   * 0.95
+   set in1_max  1.5   * 1.05
+   set in2_min  3.3   * 0.95
+   set in2_max  3.3   * 1.05
+   set in3_min  5     * 0.95
+   set in3_max  5     * 1.05
+   set in4_min 12     * 0.95
+   set in4_max 12     * 1.05
+   set in7_min  5     * 0.95
+   set in7_max  5     * 1.05
+
+### Temperatures
+
+   label temp1 "VRM Temp" # This is unconfirmed, Possibly near NB, but the NB
+   set   temp1_min 0      # operates at significantly higher temps than temp1
+   set   temp1_max 65     # Default max fan speed reference point
+
+   label temp2  "SB Temp" # This sensor reacts to nearby heat from the GPU
+   set   temp2_min 0
+   set   temp2_max 55     # Tropical ambient temperature plus a bit
+
+   label temp3 "CPU Temp" # k10temp truncated to whole number +12C. k10temp
+   set   temp3_min 0      # reports thermal margin, and reports -10C when idle
+   set   temp3_max 65     # Bulldozer Published limit +3C
+

--- a/configs/Gigabyte/H67MA-UD2H.conf
+++ b/configs/Gigabyte/H67MA-UD2H.conf
@@ -1,0 +1,55 @@
+# Provided by Ivan Bulatovic, who says it might possibly work on other
+# P65/H61/H67 Gigabyte boards too.
+
+
+chip "it8728-*"
+
+    label in0 "Vtt"
+    set in0_min 1.02    # I'm liberal with these, 2-3% tops
+    set in0_max 1.08    # after that, cpu gets very unstable
+
+    ignore in1
+#   label in1 "+3.3V"
+#   set in1_min 3.14    # Some boards including GA-H67MA-UD2H
+#   set in1_max 3.47    # don't have 3.3V voltage reading
+
+    label in2 "+12V"
+    set in2_min 11.40   # according to ATX 12V PSU design guide
+    set in2_max 12.60   #
+
+    ignore in3          # reports 3VSB
+
+    ignore in4          # really don't know what's this one for
+
+    label in5 "Vcore"
+    set in5_min 0.65
+    set in5_max 1.50    # heavy o/c
+
+    label in6 "Vdram"
+    set in6_min 1.45    # adjust these, 1.35 for LVDDR3
+    set in6_max 1.55    # 1.5V is recommended, 1.65 tops
+     
+    label in7 "3VSB"
+    set in7_min 3.14
+    set in7_max 3.47
+
+    label in8 "Vbat"
+
+    label fan1 "CPU fan"
+    set fan1_min 700
+
+    label fan2 "System fan"
+    set fan2_min 0
+
+    label temp1 "PCH temp"
+    set temp1_min 10
+    set temp1_max 60    # seen those rising to 55C
+
+    label temp2 "CPU temp"
+    set temp2_min 10
+    set temp2_max 85
+
+    ignore temp3
+
+    compute in1 1.649*@,@/1.649 # multipliers provided by 
+    compute in2 4.090*@,@/4.090 # Martin Malik author of hwinfo

--- a/configs/Gigabyte/K8N51GMF-9.conf
+++ b/configs/Gigabyte/K8N51GMF-9.conf
@@ -1,0 +1,73 @@
+# Preliminary configuration file contributed by Denzel Holmes.
+# Improvements welcome.
+
+# lm_sensors configuration for Gigabyte GA-K8N51GMF-9 (C51-MCP51) Socket 7 motherboard
+
+chip "k8temp-*"
+
+## cpu core temp ##
+ label temp1_input "CPU Core1 Temp"
+ label temp3_input "CPU Core2 Temp"
+
+chip "w83627ehf-*"
+
+## Voltage ##
+ 
+ label in0 "VCore" # CPU Core Voltage
+ label in1 "VPCIEx" # PCI Express Voltage
+ label in2 "AVCC"
+ label in3 "3VCC"
+ label in6 "+3.3V" # +3.3V, or so i think 
+ label in7 "3VSB"
+ label in8 "VBat"
+ label in9 "+12V" # +12V, or so i think
+
+## +12V is in9 and +5V is in6 ##
+ compute in9 @*(1+(56/10)), @/(1+(56/10))
+ compute in6 @*1.78, @/1.78
+
+ set in9_min 12.0*0.7916
+ set in9_max 12.0*1.1
+ set in6_min 3.3*0.9
+ set in6_max 3.3*1.10
+
+ set in0_min 0.9
+ set in0_max 1.7
+ set in1_min 1.3
+ set in1_max 2.0
+ set in2_min 3.3*0.9
+ set in2_max 3.3*1.1
+ set in3_min 3.3*0.9
+ set in3_max 3.3*1.1
+ set in4_min 1.4
+ set in4_max 1.6
+ set in5_min 1.86
+ set in5_max 1.9
+ set in7_min 3.3*0.9
+ set in7_max 3.3*1.1
+ set in8_min 3.0*0.9
+ set in8_max 3.3*1.1
+ 
+ ## Temperatures ##
+
+ label temp1 "Sys Temp"
+ label temp2 "CPU Temp"
+ label temp3 "Aux Temp"
+
+ set temp1_max 55
+ set temp1_max_hyst 48
+ set temp2_max 55
+ set temp2_max_hyst 47
+ set temp3_max 55
+ set temp3_max_hyst 50
+
+## Fans ##
+
+ label fan1 "Sys Fan"
+ label fan2 "CPU Fan"
+ 
+ set fan2_min 800
+
+ ignore fan3
+ ignore fan4
+ ignore fan5

--- a/configs/Gigabyte/M61P-S3.conf
+++ b/configs/Gigabyte/M61P-S3.conf
@@ -1,0 +1,63 @@
+# Configuration contributed by Artem S. Tashkinov.
+
+
+# lm_sensors configuration for Gigabyte M61P-S3 AM2+ motherboard
+
+chip "it8716-*"
+
+# Voltages
+
+    label  in0  "VCore"    # CPU Core Voltage
+    label  in1  "VDDR"     # DDR2 1.8V
+    label  in2  "+3.3V"    # VCC3
+    label  in3  "+5V"      # VCC
+    label  in4  "+12V"
+    label  in5  "-12V"     # Not in the BIOS, maybe not really -12V
+    label  in6  "-5V"      # Not in the BIOS, maybe not really -5V
+    label  in7  "5VSB"     # VCCH
+    label  in8  "VBat"
+
+    compute in3  ((6.8/10)+1)*@ , @/((6.8/10)+1)
+    compute in4  ((30/10)+1)*@  , @/((30/10)+1)
+    compute in5 -(30/10+1)*@, -@/(30/10+1)
+    compute in6  (1+120/56)*@ - 4.096*120/56 , (@ + 4.096*120/56)/(1+120/56)
+    compute in7  ((6.8/10)+1)*@ , @/((6.8/10)+1)
+
+#    Not setting in0 min/max, because different AMD CPUs have
+#    different voltages, besides with C'n'Q enabled this voltage
+#    can fluctuate a lot
+#    set in0_min  vid * 0.95
+#    set in0_max  vid * 1.05
+     set in1_min  1.8 * 0.95
+     set in1_max  1.8 * 1.05
+     set in2_min  3.3 * 0.95
+     set in2_max  3.3 * 1.05
+     set in3_min    5 * 0.95
+     set in3_max    5 * 1.05
+     set in4_min   12 * 0.95
+     set in4_max   12 * 1.05
+     set in5_max  -12 * 0.95
+     set in5_min  -12 * 1.05
+     set in6_max   -5 * 0.95
+     set in6_min   -5 * 1.05
+     set in7_min    5 * 0.95
+     set in7_max    5 * 1.05
+# The chip does not support in8 min/max
+
+# Temperatures
+
+    label  temp1  "M/B Temp"
+    label  temp2  "CPU Temp"
+    label  temp3  "M/B Temp"
+
+    set temp2_max   60
+
+# Fans
+
+    label  fan1 "CPU Fan"
+    label  fan2 "Case Fan"
+    ignore fan3  # This motherboard doesn't have the second system fan
+
+#   My fans can stop if the temperature is OK, adjust for your situation
+#   set fan1_min 2000
+#   set fan2_min 2000

--- a/configs/Gigabyte/MA770-DS3.conf
+++ b/configs/Gigabyte/MA770-DS3.conf
@@ -1,0 +1,126 @@
+# Configuration file contributed by Charles A. from India.
+
+
+# libsensors configuration file for Gigabyte GA-MA770-DS3 motherboard
+
+chip "it8718-*"
+
+    # lmsensors' values were compared with values from monitoring 
+    # software running on the same computer under Windows XP SP2 
+    # abbreviated in comments:
+    #   ET6: Gigabyte's EasyTune 6    
+    #   Everest: Lavalys's Everest Ultimate 4.6.0 (trial version)
+    #   OverDrive: AMD's OverDrive 2.1.5
+
+    # Labels are copied from BIOS setup screens when value shown
+
+    # Voltages
+
+    label   in0 "Vcore"
+		# BIOS: 1.264V, ET6: 1.260, Everest: 1.26, OverDrive: 1.26
+		# No scaling so no compute
+		# Values seen using powernow-k8 in "on demand" mode: 
+		# 1.06, 1.07, 1.25, 1.26, 1.28
+		# Nominal values written to /var/log/kern.log by powernow-k8
+		# as vid numbers in hex.  For AMD K8, these translate to V by 
+		# 1.550 - 0.025 * vid. Gave 1.000, 1.175 and 1.200 V
+    set     in0_min 1.000 * 0.95  # 95% of nominal min
+    set     in0_max 1.200 * 1.05  # 105% of nominal max
+
+    label   in1 "DDR2 1.8V"
+		# No scaling so no compute
+    set     in1_min 1.8 * 0.95 # 95% of nominal
+    set     in1_max 1.8 * 1.05 # 105% of nominal
+
+    label   in2 "+3.3V"
+		# No scaling so no compute
+    set     in2_min 3.3 * 0.95 # 95% of nominal
+    set     in2_max 3.3 * 1.05 # 105% of nominal
+
+    label   in3 "Vcc"
+		# BIOS: -, ET6: -, Everest: -, OverDrive: -
+		# dmesg reports as VCC 
+		# Assume standard Winbond scaling resistors
+    compute in3 @ * ((6.8/10)+1), @ / ((6.8/10)+1)
+    set     in3_min 5 * 0.95 # 95% of nominal
+    set     in3_max 5 * 1.05 # 105% of nominal
+
+    label   in4 "5VSB?" # Guess
+		# BIOS: -, ET6: -, Everest: -, OverDrive (VIN4): 12.74
+		# Values seen: 3.15, 3.17, 3.19
+		# Assume standard Winbond scaling resistors
+    compute in4 @ * ((6.8/10)+1), @ / ((6.8/10)+1)
+    set     in4_min 5 * 0.95 # 95% of nominal
+    set     in4_max 5 * 1.05 # 105% of nominal
+
+    label   in5 "+12V"
+		# BIOS: 12.619V, ET6: 12.610, Everest: -, OverDrive: -
+		# Assume standard Winbond scaling resistors
+    compute in5 @ * ((30/10)+1), @ / ((30/10)+1)
+    set     in5_min 12 * 0.95 # 95% of nominal
+    set     in5_max 12 * 1.05 # 105% of nominal
+
+    ignore  in6 # Seen always 4.08, too big (max 4.096) to signify
+    ignore  in7 # Seen always 0.03, too small to be significant
+
+    label   in8 "Vbat"
+		# BIOS: -, ET6: -, Everest:  3.17, OverDrive: - 
+		# Connected directly so no compute
+    # in8_min and _max not supported by chip
+
+    ignore  cpu0_vid # Not dynamic under lm-sensors 3.0.0
+
+    # Temperatures
+
+    label   temp1  "Current System Temperature"
+		# BIOS: 30, ET6: 30, Everest: 33, OverDrive: -
+    compute temp1 @ -5, @ +5 # Correct bad sensor on Charles' mobo
+    set     temp1_min 0
+    set     temp1_max 45 # Tropical ambient max plus a bit
+
+    label   temp2  "Current CPU Casing Temperature"     
+		# BIOS: 29, ET6: 28, Everest: 32, OverDrive (both cores): 33
+    set     temp2_min 0
+		# Max is lowest available BIOS "CPU Warning Temperature" - 5
+    set     temp2_max 55 
+
+    ignore  temp3
+		# Values seen: 77-79, rising from cold start.
+		# Sheilding Northbridge from CPU cooling draft did not change
+
+    # Fans
+    # The labels chosen are the ones printed on the motherboard
+    label   fan1 "CPU_FAN"
+    set     fan1_min 0 # fancontrol may stop fan
+    label   fan2 "SYS_FAN1"
+    label   fan3 "SYS_FAN2"
+    ignore  fan4 # "NB_FAN" does not set an RPM signal
+    label   fan5 "PWR_FAN"
+
+    # Beep
+    # lm-sensors 3.0.0 does not support on this chip
+    # Was enabled by default
+
+chip "k8temp-*"
+
+    # Temperatures
+    # For CPU revisions F and G, according to AMD's "Revision 
+    # Guide for AMD NPT Family 0Fh Processors", "The internal 
+    # thermal sensor ... is inaccurate". This may be the reason 
+    # for many reports of k8temp giving absurdly low CPU core 
+    # temperatures and for there being no generally accepted 
+    # computation to derive actual temperature from the raw data. 
+    # The workaround is to ignore core temperatures and use the 
+    # CPU case temperature as was done before core temperatures 
+    # were available. On this motherboard the CPU case temperature 
+    # is reported by the it8718 chip's temp2 (see above).
+
+    # For CPU revisions other than F and G, the proper use of 
+    # k8temp temperatures may be to compute an average for each 
+    # core rather than to report two temperatures for each core. 
+    # For a sample computation see mingus' posting at
+    # http://forums.opensuse.org/archives/sls-archives/archives-suse-linux/archives-hardware-support/381563-lm-sensors-2.html#post1793098
+
+    # If you don't trust the readings, you might as well not load
+    # the k8temp driver (which, in practice, means blacklisting it,
+    # as this driver auto-loads on most systems.

--- a/configs/Gigabyte/MA785GM-US2H.conf
+++ b/configs/Gigabyte/MA785GM-US2H.conf
@@ -1,0 +1,81 @@
+# Contributed by Glen Journeay and David Santamaría Rogado.
+
+
+# lm_sensors 3 configuration file for the Gigabyte MA785GM-US2H motherboard
+# 2010-8-12 G. Journeay <journeay@gmail.com>
+# 2011-04-17, David Santamaría Rogado <howl.nsp@gmail.com>
+# Written for board revision 1.0, may or may not be suitable for other
+# revisions.
+# Comments welcome!
+
+chip "it8718-*"
+
+### Voltages
+
+   # in7 is mysterious, it lives in the range 2.19 to 2.94 V, change with
+   # CPU frequency (if you take the highest clock speed of all the cores
+   # you can guess it's value). No idea what it can be.
+
+   label  in0  "Vcore"
+   label  in1  "Vram"    # "DDR2" in BIOS
+   label  in2  "+3.3V"
+   label  in3  "+5V"     # Not in BIOS
+   label  in4  "+12V"
+   ignore in5            # Always fixed at 4.08 V
+   ignore in6            # Always fixed at 4.02 V
+   ignore in7            # Commented above
+   label  in8  "Vbat"    # Not in BIOS
+
+   # Vcore, Vram, +3.3V and Vbat are connected directly, so no compute
+   # line is needed for these. For +5V the chip is configured to use
+   # internal scaling. For +12V, my guess is that the BIOS uses 4 as
+   # the scaling factor. Not sure if it matches the physical reality.
+   # BIOS values varies between 12.048 and 12.112 V, lm-sensors in4
+   # between 3.040 and 3.056 V, is exactly a x4 scale +0.112 offset.
+
+   compute  in3  @ * (6.8/10+1),   @ / (6.8/10+1)
+   compute  in4  @ * ((30/10)+1),  @ / ((30/10)+1)
+
+   # The BIOS won't set any limit for voltages.
+   # You should set Vcore and Vram to match you setup, mine is:
+   # - CPU: AMD Athlon II X2 250 (VCore 0.85-1.425)
+   # - Mem: KHX8500D2/2G (Vram 1.8-2)
+
+   set in0_min 0.850 * 0.95
+   set in0_max 1.425 * 1.05
+   set in1_min 1.8 * 0.95
+   set in1_max 2.0 * 1.05
+   set in2_min 3.3 * 0.95
+   set in2_max 3.3 * 1.05
+   set in3_min   5 * 0.95
+   set in3_max   5 * 1.05
+   set in4_min  12 * 0.95
+   set in4_max  12 * 1.05
+
+### Temperatures
+
+   # The BIOS only shows 2 temperature values, corresponding to Sys and CPU,
+   # temp3 is usually similar to Sys temp but under heavy load it raises more.
+
+   label  temp1  "Sys Temp"
+   label  temp2  "CPU Temp"
+   label  temp3  "NBr Temp"    # Guessed
+
+   set temp1_min 10
+   set temp1_max 50
+   set temp2_min 10
+   set temp2_max 60
+   set temp3_min 10
+   set temp3_max 50
+
+### Fans
+
+   label  fan1  "CPU Fan"
+   label  fan2  "Case Fan"
+   ignore fan3
+   label  fan4  "NBr Fan"
+
+   # Adjust for your own fans
+   set fan1_min 1000
+   set fan2_min 1000
+   set fan4_min 1000

--- a/configs/Gigabyte/P55-US3L.conf
+++ b/configs/Gigabyte/P55-US3L.conf
@@ -1,0 +1,73 @@
+# Contributed by Yuri Nefedov (Russia.)
+
+
+# Gigabyte P55-US3L (rev 1:0, BIOS F1)
+# 
+
+chip "it8720-*"
+
+# Voltages
+
+    label  in0  "VCore1"        # ok
+    label  in1  "DDR15V"        # ok
+    label  in2  "+3.3V"         # ok
+    label  in3  "+5V"           # ok
+#    ignore in4                 # ?? correlates with load_av/temp3/fan1 [0;2.4]
+    label  in5  "+12V"          # ok
+#    ignore in6                 # ?? correlates with load_av/temp3/fan1 [0;0.3]
+    label  in7  "5VSB"          # internal
+    label  in8  "VBat"
+
+    compute in3  ((6.8/10)+1)*@ , @/((6.8/10)+1)
+    compute in5  ((28/10)+1)*@  , @/((28/10)+1)
+    compute in7  ((6.8/10)+1)*@ , @/((6.8/10)+1)
+
+#   VID Voltage Range for core-i5 750 
+#   (http://ark.intel.com/Product.aspx?id=42915)
+    set in0_min  0.65
+    set in0_max  1.40
+
+    set in1_min  1.4            # depends from BIOS settings
+    set in1_max  1.6            # correct if it is wrong
+
+    set in2_min  3.3 * 0.95
+    set in2_max  3.3 * 1.05
+
+    set in3_min    5 * 0.95
+    set in3_max    5 * 1.05
+
+    set in5_min   12 * 0.95
+    set in5_max   12 * 1.05
+
+    set in7_min    5 * 0.90
+    set in7_max    5 * 1.10
+
+#    set in4_max   4.08 
+#    set in6_max   4.08 
+# The chip does not support in8 min/max
+
+# Temperatures
+#
+# see man sensors.conf for available thermal sensor types.
+# 
+#   set temp1_type 4
+
+    label  temp1   "PCH Temp"   # PCH is the south bridge 
+    ignore temp2
+    label  temp3   "CPU Temp"
+
+    set temp1_max  50
+    set temp3_max  70
+
+# Fans
+
+# The motherboard has connectors: cpu_fan, sys_fan1/2, pwr_fan
+# case fan == sys_fan1
+
+    label  fan1 "CPU Fan"
+    ignore fan2
+    ignore fan3
+    label  fan4 "Case Fan"
+
+    set fan1_min 1000
+    set fan4_min 0

--- a/configs/Gigabyte/X58-UD3R.conf
+++ b/configs/Gigabyte/X58-UD3R.conf
@@ -1,0 +1,38 @@
+# Partial configuration file for the Gigabyte X58-UD3R, reported to work fine
+# on the X58A-UD3R as well.
+
+# libsensors3 configuration file for the Gigabyte X58-UD3R
+
+chip "it8720-*"
+
+# Voltages
+
+    label  in0  "VCore"
+    label  in1  "DDR15V"
+    label  in2  "+3.3V"
+    label  in3  "+5V"
+    ignore in4
+    label  in5  "+12V"
+    ignore in6
+    label  in7  "5VSB"          # internal
+    label  in8  "Vbat"
+
+    # Exact scaling for +12V is unknown
+    compute in3  ((6.8/10)+1)*@ , @/((6.8/10)+1)
+    compute in5  3.964*@  , @/3.964
+    compute in7  ((6.8/10)+1)*@ , @/((6.8/10)+1)
+
+    set in0_min  0.65
+    set in0_max  1.40
+    set in1_min  1.4            # depends from BIOS settings
+    set in1_max  1.6            # correct if it is wrong
+    set in2_min  3.3 * 0.95
+    set in2_max  3.3 * 1.05
+    set in3_min    5 * 0.95
+    set in3_max    5 * 1.05
+    set in5_min   12 * 0.95
+    set in5_max   12 * 1.05
+    set in7_min    5 * 0.90
+    set in7_max    5 * 1.10
+
+   ignore cpu0_vid

--- a/configs/Gigabyte/Z38MX-UD2H-B3.conf
+++ b/configs/Gigabyte/Z38MX-UD2H-B3.conf
@@ -1,0 +1,93 @@
+# Configuration file contributed by Martin Herrman.
+
+
+# LM-Sensors config file for Gigabyte GA-Z38MX-UD2H-B3 mainboard with 
+# an Intel i5 Sandy Bridge quad core CPU installed.
+
+# Tested with kernel 3.10.x and lm-sensors 3.3.x on Gentoo Linux.
+
+# Created by Martin Herrman <martin@herrman.nl> with help from Jean Delvare
+# from the lm-sensors mailinglist.
+
+# Questions, comments or additions? Please share on the lm-sensors mailinglist.
+# More info at http://www.lm-sensors.org/wiki/FeedbackAndSupport
+
+# Hint: Use sensors -u to list all variables.
+http://lists.lm-sensors.org/pipermail/lm-sensors/2014-January/040952.html
+chip "coretemp-*"
+# chip coretemp measures cpu temperatures from i5 CPU temperature sensor
+# _max, _crit and _crit_alarm are read from the cpu itself
+# when temp is at _max, all cooling options must be at full throttle
+# when temp is at _crit, cpu starts to fail
+# _crit_alarm is automatically set by hardware when _input is at or above _crit
+# libsensors currently doesn't support the trigger of a notification system
+label temp1 "CPU Package temp"
+label temp2 "Core 0"
+label temp3 "Core 1"
+label temp4 "Core 2"
+label temp5 "Core 3"
+
+# IT8728F is on the mainboard and provides voltages and cpu/case fan speed
+chip "it8728-*"
+
+# scythe kozuti min = 800
+# output of sensors will show ALARM (_alarm is set to 1) when actual fan 
+# speed (_input) is below set minimum (_min). If _beep is set to 1, and
+# the motherboard is wired between the temperature sehttp://lists.lm-sensors.org/pipermail/lm-sensors/2014-January/040952.htmlnsor and the
+# PC speaker, the PC speaker will start beeping.
+# Unfortunately Gigabyte GA-Z68MX-UD2H-B3 is not properly wired.
+label fan1 "CPU fan"
+set fan1_min 800 
+set fan1_beep 1
+
+# I don't have a case fan installed via PWM
+label fan2 "Case fan"
+#set fan2_min 1000
+#set fan2_beep 1
+
+# Motherboard temps
+ 
+# Note: tempX_type indicates the type of sensor and is set by the BIOS
+
+# When comparing temp1 and temp2 with BIOS value, temp1 seems to be similar to BIOS system temperature.
+# temp2 increases like temp1 does, so I assume that it is another case temp but not shown in BIOS.
+label temp1 "Case temp (shown in BIOS)"
+label temp2 "Case temp (hidden in BIOS)"
+
+# The reported values seem to be correct. No need to add offset or compute. 
+
+# Let's set some real world values for min and max
+set temp1_min 25
+set temp1_max 50
+set temp2_min 25
+set temp2_max 50
+
+# Let's alarm when temperatures are outside range
+set temp1_beep 1
+set temp2_beep 1
+
+# temp3 increases when cpu high load, so assuming this is CPU temperature.
+label temp3 "CPU temp"
+
+# Note: PECI value is negative value relative to _crit, but driver calculates
+# to real value.
+
+# Adding 10 to correct wrong BIOS values.
+# Change offset is more efficient than computing new value, because offset is done in hardware.
+# Note: using compute also increases min and max values. You will need to set the min and max values below.
+# Note: offset default value is 72, so add 10 makes 82.
+#compute temp3 @+10,@-10
+set temp3_offset 82
+
+# In BIOS it is possible to set CPU warning temperature, but this does not influence
+# temp3_input. However, it does change the temp3_max. My bios setting is at 60
+# degrees. Coretemp defines maximum of 76. I want a warning at 60.
+# _min, _max
+set temp3_min 25
+#set temp3_max 60
+
+# Let's alarm when temperature is outside range
+set temp3_beep 1
+
+# ignore intrusion detection (case open?)
+ignore intrusion0

--- a/configs/Gigabyte/Z77-D3H.conf
+++ b/configs/Gigabyte/Z77-D3H.conf
@@ -1,0 +1,78 @@
+# Configuration file  contributed by Mathias Gerber.
+
+
+chip "acpitz-virtual-0"
+    ignore temp1 # stays always at 27.8 degrees C
+    ignore temp2 # dito
+
+chip "it8728-*"
+
+    label in0 "CPU Vtt"
+    set in0_min 1.02    # I'm liberal with these, 2-3% tops
+    set in0_max 1.08    # after that, cpu gets very unstable
+
+    label in1 "+3.3V"
+    set in1_min 3.3 * 0.95    # Some boards including GA-H67MA-UD2H
+    set in1_max 3.3 * 1.05    # don't have 3.3V voltage reading
+    compute in1 1.649*@,@/1.649 # multipliers provided by Martin Malik author of hwinfo
+
+    label in2 "+12V"
+    set in2_min 12 * 0.95
+    set in2_max 12 * 1.05
+    compute  in2  @ * (72/12), @ / (72/12) #mg,15.05.13
+
+    label in3 "+5V"
+    set in3_min 5 * 0.95
+    set in3_max 5 * 1.05
+    compute in3 2.5*@,@/2.5
+
+    label in4 "Vaxg"	# Voltage used by the video controller embedded inside the CPU
+    set in4_min 0.4
+    set in4_max 1.4
+
+    label in5 "Vcore"
+    set in5_min 0.825 * 0.95
+    set in5_max 1.425 * 1.05
+
+    label in6 "Vdram"
+    set in6_min 1.5 * 0.95    # adjust these, 1.35 for LVDDR3
+    set in6_max 1.5 * 1.05    # 1.5V is recommended, 1.65 tops
+     
+    # 3VSB
+    set in7_min 3.3 * 0.95
+    set in7_max 3.3 * 1.05
+
+    # Vbat
+    set in8_min  3.0 * 0.90
+    set in8_max  3.0 * 1.10
+
+### fan
+
+    label fan1 "CPU fan"
+    set fan1_min 700
+
+    label fan2 "Sys1 fan"
+    set fan2_min 200
+
+    label fan3 "Sys2 fan"
+    set fan3_min 200 
+
+    label fan4 "Sys3 fan"
+    set fan4_min 200 
+
+    label fan5 "Sys4 fan"
+    set fan5_min 200 
+
+### temperatures
+
+    label temp1 "System temp" # tops at 33 degrees C
+    set temp1_min 10
+    set temp1_max 60
+
+    ignore temp2 # shows always 25 degrees C
+    set temp2_min 0
+    set temp2_max 60
+
+    label temp3 "CPU temp"
+    set temp3_min 10
+    set temp3_max 85

--- a/configs/InsideTechnology/786LCD.conf
+++ b/configs/InsideTechnology/786LCD.conf
@@ -1,0 +1,52 @@
+# Example configuration file for the Inside Technology 786LCD motherboard:
+
+chip "it87-*"
+
+    label in0 "VCore 1"
+    label in1 "VCore 2"
+    label in2 "+3.3V"
+    label in3 "+5V"
+    label in4 "+12V"
+    label in5 "3.3 Stdby"
+    label in6 "-12V"
+    label in7 "Stdby"
+    label in8 "VBat"
+
+    # vid not monitored by IT8705F
+    ignore  cpu0_vid
+
+    # in0 will depend on your processor VID value, set to voltage specified in
+    # bios setup screen
+
+    compute in3 ((6.8/10)+1)*@ ,  @/((6.8/10)+1)
+    compute in4 ((30/10) +1)*@  , @/((30/10) +1)
+    compute in6 (1+232/56)*@ - 4.096*232/56, (@ + 4.096*232/56)/(1+232/56)
+    compute in7 ((6.8/10)+1)*@ ,  @/((6.8/10)+1)
+
+    set in0_min 1.7 * 0.95
+    set in0_max 1.7 * 1.05
+    set in1_min 2.4
+    set in1_max 2.6
+    set in2_min 3.3 * 0.95
+    set in2_max 3.3 * 1.05
+    set in3_min 5.0 * 0.95
+    set in3_max 5.0 * 1.05
+    # +- 12V are very poor tolerance on this board. Verified with voltmeter
+    set in4_min 12 * 0.90
+    set in4_max 12 * 1.10
+    set in5_min 3.3 * 0.95
+    set in5_max 3.3 * 1.05
+    set in6_max -12 * 0.90
+    set in6_min -12 * 1.10
+    set in7_min 5 * 0.95
+    set in7_max 5 * 1.05
+
+    # Temperature
+    label temp1       "CPU Temp"
+    ignore temp2
+    ignore temp3
+
+    # Fans
+    set fan1_min 3000
+    ignore fan2
+    ignore fan3

--- a/configs/Intel/D201GLY2.conf
+++ b/configs/Intel/D201GLY2.conf
@@ -1,0 +1,45 @@
+# Configuration file contributed by Eric Le Bras.
+
+
+# Configuration file for Intel D201GLY2 motherboard
+# Hardware monitor subsystem controlled by Winbond W83627DHG-B I/O controller.
+# Created using information from BIOS and board documentation.
+
+chip "w83627dhg-*"
+
+    label in1 "+12V"
+    label in4 "+5V"
+    label in6 "+1.5V"
+
+# in5 is obviously unconnected, so ignore it
+    ignore in5
+
+    compute in1 @*(55/8), @/(55/8)
+    compute in4 @*(1+18/10), @/(1+18/10)
+
+    set in1_min 12.0 * 0.95
+    set in1_max 12.0 * 1.05
+    set in4_min  5.0 * 0.95
+    set in4_max  5.0 * 1.05
+    set in6_min  1.5 * 0.90
+    set in6_max  1.5 * 1.10
+
+    label fan1 "Chassis fan"
+    label fan2 "CPU fan"
+
+# By default the D201GLY2 has a passive heatsink. If the optional active
+# heatsink is present, then one of the following lines is to be commented out
+# (very likely fan2, though not tried).
+    ignore fan2
+    ignore fan3
+    ignore fan4
+
+    label temp1 "Sys temp"
+    label temp2 "CPU temp"
+    ignore temp3
+
+    set temp1_max      50
+    set temp1_max_hyst 48
+
+    ignore cpu0_vid
+    ignore intrusion0

--- a/configs/Intel/D2500CC.conf
+++ b/configs/Intel/D2500CC.conf
@@ -1,0 +1,61 @@
+# Configuration file contributed by Balint Szente.
+
+
+# Intel D2500CC based on BIOS values
+#
+
+chip "w83627uhg-*"
+
+    ignore  intrusion0
+
+# Voltages
+
+    # Processor Vcc
+    label   in0            "Vcore"
+    set     in0_min        0.91 * 0.99
+    set     in0_max        1.21 * 1.01
+
+    # +3.3V
+    label   in1            "+3.3V"
+    compute in1            3.2*@, @/3.2
+    set     in1_min        3.3 * 0.95
+    set     in1_max        3.3 * 1.05
+
+    # +5.0V
+    label   in3            "+5V"
+    set     in3_min        5.0 * 0.95
+    set     in3_max        5.0 * 1.05
+
+    # +12.0V
+    label   in4            "+12V"
+    compute in4            12*@, @/12
+    set     in4_min        12 * 0.95
+    set     in4_max        12 * 1.05
+
+    # Memory Vcc
+    label   in5            "Vdimm"
+    set     in5_min        1.5 * 0.95
+    set     in5_max        1.5 * 1.05
+
+    # +5.0V Standby
+    label   in7            "5VSB"
+    set     in7_min        4.60
+    set     in7_max        5.40
+
+# Fans
+
+    label   fan1           "System Fan"
+    set     fan1_min       250
+    ignore  fan2
+
+# Temperatures
+
+    # Memory Temperature
+    label   temp1          "DIMM temp"
+    set     temp1_max      80
+    set     temp1_max_hyst 75
+
+    # VR Temperature
+    label   temp2          "VR temp"
+    set     temp2_max      80
+    set     temp2_max_hyst 75

--- a/configs/Intel/D945GCLF.conf
+++ b/configs/Intel/D945GCLF.conf
@@ -1,0 +1,55 @@
+# Configuration contributed by Marcelo Coelho.
+
+
+# Configuration for Intel DG945GCLF
+
+chip "smsc47m1-*"
+
+    label fan1 "Case Fan"
+    label fan2 "CPU Fan"
+
+chip "smsc47m192-*"
+
+    label in0 "+2.5V"
+    set in0_min  2.5 * 0.95
+    set in0_max  2.5 * 1.05
+
+    label in1 "Vcore"
+    set in1_min  0.9
+    set in1_max  1.162
+
+    label in2 "+3.3V"
+    set in2_min  3.3 * 0.90
+    set in2_max  3.3 * 1.10
+
+    label in3 "+5V"
+    set in3_min  5.0 * 0.90
+    set in3_max  5.0 * 1.10
+
+    label in4 "+12V"
+    set in4_min 12.0 * 0.90
+    set in4_max 12.0 * 1.10
+
+    label in5 "VCC"
+    set in5_min  3.3 * 0.90
+    set in5_max  3.3 * 1.10
+
+    label in6 "+1.5V"
+    set in6_min  1.5 * 0.90
+    set in6_max  1.5 * 1.10
+
+    label in7 "+1.8V"
+    set in7_min  1.8 * 0.90
+    set in7_max  1.8 * 1.10
+
+    label temp1 "Chipset Temp"
+    set temp1_min 0
+    set temp1_max 90
+
+    label temp2 "CPU Temp"
+    set temp2_min 0
+    set temp2_max 85
+
+    label temp3 "System Temp"
+    set temp3_min 0
+    set temp3_max 75

--- a/configs/Intel/DH57JG.conf
+++ b/configs/Intel/DH57JG.conf
@@ -1,0 +1,48 @@
+# Contributed by Guenter Roeck.
+
+
+chip "nct6775-*"
+
+    label in0 "VCore"
+    label in1 "+12V"
+    label in2 "AVCC"
+    label in3 "+3.3V"
+    label in4 "+5V"
+    label in5 "+1.5V"
+    label in7 "VSB"
+    label in8 "VBAT"
+
+    compute in1 16*@, @/16
+    compute in4  4*@, @/4
+    compute in5  2*@, @/2
+
+    set in0_min 0.5
+    set in1_min  12 * 0.9
+    set in1_max  12 * 1.1
+    set in2_min 3.3 * 0.9
+    set in2_max 3.3 * 1.1
+    set in3_min 3.3 * 0.9
+    set in3_max 3.3 * 1.1
+    set in4_min   5 * 0.9
+    set in4_max   5 * 1.1
+    set in5_min 1.5 * 0.9
+    set in5_max 1.5 * 1.1
+    set in7_min 3.3 * 0.90
+    set in7_max 3.3 * 1.10
+    set in8_min 3.0 * 0.90
+    set in8_max 3.0 * 1.10
+
+    ignore in6
+
+    set temp1_max       70
+    set temp1_max_hyst  60
+    set temp2_max       70
+    set temp2_max_hyst  60
+    set temp3_max       70
+    set temp3_max_hyst  60
+
+    # PCH is used to control the fans
+    ignore fan1
+    ignore fan2
+    ignore fan3
+    ignore fan4

--- a/configs/Intel/DH67BL.conf
+++ b/configs/Intel/DH67BL.conf
@@ -1,0 +1,95 @@
+# Configuration file contributed by Arseny Klimovsky.
+
+
+# Created for board DH67BL using information from Intel Desktop Utilities and BIOS
+# "FRONT" and "REAR" fan labels correspond to the motherboard
+# headers, but not necessarily the actual fan locations.
+
+chip "nct6775-isa-0290"
+
+# Fans
+        label fan1 "Rear fan"
+        set fan1_min 250 # From IDU
+
+        label fan2 "CPU fan"
+        set fan2_min 250 # From IDU
+
+        label fan3 "Front fan"
+        set fan3_min 250 # From IDU
+
+	# There is no fan4 on the board
+	ignore fan4
+
+# Voltages
+
+	# Processor Vcc
+	label	in0		"Vcore"
+	set	in0_min 	0.6 # From IDU
+	set	in0_max 	1.6 # From IDU
+	
+	# This should be "12 Volts", but computations are strange
+	label	in1		"+12V"
+	compute	in1		11*@, @/11
+	set	in1_min		11.1 # From IDU
+	set	in1_max		12.9 # From IDU
+
+	# AVCC(?) - Not shown in BIOS or IDU
+	label	in2		"AVCC"
+	set	in2_min		3.0		# same as +3.3V
+	set	in2_max		3.6		# same as +3.3V
+
+	# +3.3 Volts
+	label	in3		"+3.3V"
+	set	in3_min		3.0		# from IDU
+	set	in3_max		3.6		# from IDU
+
+	# +5 Volts
+	label	in4		"+5V"
+	compute	in4		5*@, @/5
+	set	in4_min		4.6		# from IDU
+	set	in4_max		5.4		# from IDU
+
+	# Memory Vcc ("SDRAM Vcc" in IDU)
+	label	in5		"MemV"
+	compute	in5		1.5*@, @/1.5
+	set	in5_min		0.4		# from IDU
+	set	in5_max		2.0		# from IDU
+
+	# PCH Vcc
+	label	in6		"PCHV"
+	set	in6_min		0.6		# from IDU
+	set	in6_max		1.6		# from IDU
+
+	# +3.3 Volt Standby
+	label	in7		"3VSB"
+	set	in7_min		3.0		# from IDU
+	set	in7_max		3.6		# from IDU
+
+	# VBAT(?) - Not shown in BIOS or IDU
+	label	in8		"Vbat"
+
+	# It shows +2.050 V, seems to be not used
+	ignore	cpu0_vid
+
+#	Temperatures
+
+	# Labeled as "SYSTIN"
+	# Guess!
+	label	temp1		"VR temp"
+	set	temp1_max 	90		# From IDU
+	set	temp1_max_hyst 	75		# From IDU
+	# Labeled as "CPUTIN"
+	label	temp2		"CPU temp"
+	set	temp2_max 	93		# From IDU
+	set	temp2_max_hyst 	75		# From IDU
+	# Labeled as "PECI Agent 0"
+	# Guess!
+	label	temp3		"Memory DIMM temp"
+	set	temp3_max 	90		# From IDU
+	set	temp3_max_hyst 	75		# From IDU
+	# Labeled as "PCH_CHIP_TEMP"
+	label	temp4		"PCH temp"
+
+	# Labeled as "PECI Agent 1"
+	# Not used
+	ignore	temp8

--- a/configs/Intel/DN2800MT.conf
+++ b/configs/Intel/DN2800MT.conf
@@ -1,0 +1,64 @@
+# Configuration file contributed by Balint Szente.
+
+
+# Intel DN2800MT based on BIOS values
+#
+
+chip "w83627dhg-*"
+
+    ignore  cpu0_vid
+    ignore  intrusion0
+
+# Voltages
+
+    # Processor Vcc
+    label   in0            "Vcore"
+    set     in0_min        0.75 * 0.99
+    set     in0_max        1.21 * 1.01
+
+    # +12.0V
+    label   in1            "+12V"
+    compute in1            12*@, @/12
+    set     in1_min        12 * 0.95
+    set     in1_max        12 * 1.05
+
+    # +3.3V
+    label   in3            "+3.3V"
+    set     in3_min        3.3 * 0.95
+    set     in3_max        3.3 * 1.05
+
+    # +5.0V
+    label   in4            "+5V"
+    compute in4            5*@, @/5
+    set     in4_min        5.0 * 0.95
+    set     in4_max        5.0 * 1.05
+
+    # Memory Vcc
+    label   in5            "Vdimm"
+    set     in5_min        1.5 * 0.95
+    set     in5_max        1.5 * 1.05
+
+    # PCH Vcc
+    label   in6            "PCH"
+    set     in6_min        1.05 * 0.95
+    set     in6_max        1.05 * 1.05
+
+    # +3.3V Standby
+    label   in7            "3VSB"
+    set     in7_min        3.3 * 0.95
+    set     in7_max        3.3 * 1.05
+
+# Temperatures
+
+    # Memory Temperature
+    label   temp1          "DIMM temp"
+    set     temp1_max      80
+    set     temp1_max_hyst 75
+
+    # Always on 110.5
+    ignore  temp2
+
+    # VR Temperature
+    label   temp3          "VR temp"
+    set     temp3_max      80
+    set     temp3_max_hyst 75

--- a/configs/Intel/DP55WB.conf
+++ b/configs/Intel/DP55WB.conf
@@ -1,0 +1,18 @@
+# Contributed by Roderick Johnstone and Jean Delvare.
+
+
+chip "adt7490-i2c-*-2c"
+
+   label  in0  "Vdimm"
+   label  in1  "Vcore"
+   label  in2  "+3.3V"
+   label  in3  "+5V"
+   label  in4  "+12V"
+
+   ignore temp1
+   label  temp2  "M/B Temp"
+
+   label  fan1  "CPU Fan"
+   label  fan2  "Front Fan"
+   label  fan3  "Rear Fan"
+   ignore fan4

--- a/configs/Intel/DQ67EP.conf
+++ b/configs/Intel/DQ67EP.conf
@@ -1,0 +1,94 @@
+# Created for board DQ67EP using information from Intel Desktop Utilities and BIOS
+# "FRONT" and "REAR" fan labels correspond to the motherboard
+# headers, but not necessarily the actual fan locations.
+
+chip "nct6775-isa-0290"
+
+# Fans
+        label fan1 "Rear fan"
+        set fan1_min 250 # From IDU
+
+        label fan2 "CPU fan"
+        set fan2_min 250 # From IDU
+
+	# There is no fan3 on the board
+	ignore fan3
+
+	# There is no fan4 on the board
+	ignore fan4
+
+# Voltages
+
+	# Processor Vcc
+	label	in0		"Vcore"
+	set	in0_min 	0.6 # From IDU
+	set	in0_max 	1.6 # From IDU
+	
+	# This should be "12 Volts", but computations are strange
+	label	in1		"+12V"
+	compute	in1		16*@, @/16
+	set	in1_min		11.1 # From IDU
+	set	in1_max		12.9 # From IDU
+
+	# AVCC(?) - Not shown in BIOS or IDU
+	label	in2		"AVCC"
+	set	in2_min		3.1		# same as +3.3V
+	set	in2_max		3.5		# same as +3.3V
+
+	# +3.3 Volts
+	label	in3		"+3.3V"
+	set	in3_min		3.1		# from IDU
+	set	in3_max		3.5		# from IDU
+
+	# +5 Volts
+	label	in4		"+5V"
+	compute	in4		4*@, @/4
+	set	in4_min		4.7		# from IDU
+	set	in4_max		5.3		# from IDU
+
+	# Memory Vcc ("SDRAM Vcc" in IDU)
+	label	in5		"+1.5V"
+	set	in5_min		1.4		# from IDU
+	set	in5_max		1.6		# from IDU
+
+	# PCH Vcc
+	label	in6		"PCH"
+	set	in6_min		0.6		# from IDU
+	set	in6_max		1.6		# from IDU
+
+	# +3.3 Volt Standby
+	label	in7		"3VSB"
+	set	in7_min		3.1		# from IDU
+	set	in7_max		3.5		# from IDU
+
+	# VBAT(?) - Not shown in BIOS or IDU
+	label	in8		"Vbat"
+
+	# It shows +2.050 V, seems to be not used
+	ignore	cpu0_vid
+
+#	Temperatures
+
+	# Labeled as "SYSTIN"
+	# Guess!
+	label	temp1		"DIMM temp"
+	set	temp1_max 	80		# From IDU
+	set	temp1_max_hyst 	75		# From IDU
+
+	# Labeled as "CPUTIN"
+	label	temp2		"VR temp"
+	set	temp2_max 	80		# From IDU
+	set	temp2_max_hyst 	75		# From IDU
+
+	# Labeled as "PECI Agent 0"
+	# Guess!
+	label	temp3		"CPU temp"
+	set	temp3_max 	80		# From IDU
+	set	temp3_max_hyst 	75		# From IDU
+
+	# Labeled as "PCH_CHIP_TEMP"
+	label	temp7		"PCH temp"
+
+	# Labeled as "PECI Agent 1"
+	# Not used
+	ignore	temp8

--- a/configs/Intel/DQ67SW.conf
+++ b/configs/Intel/DQ67SW.conf
@@ -1,0 +1,342 @@
+# Configuration files contributed by Ian Pilcher.
+# The first one is for old BIOS versions:
+
+################################################################################
+#
+#
+#	lm_sensors configuration for Intel DQ67SW
+#
+#	NOTES:
+#
+#		BIOS = SWQ6710H.86A.0050.2011.0401.1409 (01-Apr-2011)
+#
+#		IDU = Intel Desktop Utilities version 3.1.3.030
+#			(Windows 7 Professional SP1, 64-bit)
+#
+#		The minimum, maximum, and hysteresis values are generally the
+#		more conservative of the IDU- or BIOS-provided values.
+#
+#		"FRONT" and "REAR" fan labels correspond to the motherboard
+#		headers, but not necessarily the actual fan locations.
+#
+#		Minimum fan RPMs should be adjusted to reflect the behavior of
+#		the installed fans.
+#
+#		"Memory DIMM Temperature" is presumably measured by a diode
+#		somewhere in the vicinity of the DIMM slots; "System Temperature
+#		might be a better name.
+#
+#		80 degrees Celcius might be a bit high for the "Memory DIMM
+#		Temperature" limit.
+#
+#
+################################################################################
+
+chip "nct6775-*"
+
+	ignore	cpu0_vid
+
+	########################################################################
+	#
+	#	Voltages
+	#
+	########################################################################
+
+	#
+	# Processor Vcc
+	#
+	label	in0		"VCORE"
+	set	in0_min		0.2		# from IDU (BIOS = 0.00)
+	set	in0_max		1.6		# from IDU (BIOS = 1.74)
+
+	#
+	# +12 Volts
+	#
+	label	in1		"+12V"
+	compute	in1		16*@, @/16
+	set	in1_min		10.8		# from IDU (BIOS does not set)
+	set	in1_max		13.2		# from IDU (BIOS does not set)
+
+	#
+	# AVCC(?) - Not shown in BIOS or IDU
+	#
+	label	in2		"AVCC"
+	set	in2_min		3.1		# same as +3.3V (BIOS = 2.98)
+	set	in2_max		3.5		# same as +3.3V (BIOS = 3.63)
+
+	#
+	# +3.3 Volts
+	#
+	label	in3		"+3.3V"
+	set	in3_min		3.1		# from IDU (BIOS = 2.98)
+	set	in3_max		3.5		# from IDU (BIOS = 3.63)
+
+	#
+	# +5 Volts
+	#
+	label	in4		"+5V"
+	compute	in4		4*@, @/4
+	set	in4_min		4.7		# from IDU (BIOS does not set)
+	set	in4_max		5.3		# from IDU (BIOS does not set)
+
+	#
+	# SDRAM Vcc
+	#
+	label	in5		"+1.5V"
+	set	in5_min		1.4		# from IDU (BIOS does not set)
+	set	in5_max		1.6		# from IDU (BIOS does not set)
+
+	#
+	# PCH Vcc
+	#
+	label	in6		"PCH"
+	set	in6_min		0.6		# from IDU (BIOS does not set)
+	set	in6_max		1.6		# from IDU (BIOS does not set)
+
+	#
+	# +3.3 Volt Standby
+	#
+	label	in7		"VSB"
+	set	in7_min		3.0		# from IDU (BIOS = 2.98)
+	set	in7_max		3.6		# from IDU (BIOS = 3.63)
+
+	#
+	# VBAT(?) - Not shown in BIOS or IDU
+	#
+	label	in8		"VBAT"
+	#set	in8_min		2.7		# from BIOS
+	#set	in8_max		3.3		# from BIOS
+
+	########################################################################
+	#
+	#	Fans
+	#
+	########################################################################
+
+	ignore	fan4
+
+	#
+	# Chassis Inlet Fan
+	#
+	label	fan1		"FRONT"
+	set	fan1_min	250		# from IDU (BIOS does not set)
+
+	#
+	# Processor Fan
+	#
+	label	fan2		"CPU"
+	set	fan2_min	250		# from IDU (BIOS does not set)
+
+	#
+	# Chassis Outlet Fan
+	#
+	label	fan3		"REAR"
+	set	fan3_min	250		# from IDU (BIOS does not set)
+
+	########################################################################
+	#
+	#	Temperatures
+	#
+	########################################################################
+
+	ignore	temp8
+
+	#
+	# Memory DIMM Temperature
+	#
+	label	temp1		"DIMM"
+	set	temp1_max	80		# same as VR (IDU = 90)
+	set	temp1_max_hyst	75		# same as VR
+
+	#
+	# VR Temperature
+	#
+	label	temp2		"VR"
+	set	temp2_max	80		# from BIOS (IDU = 90)
+	set	temp2_max_hyst	75		# from BIOS
+
+	#
+	# Processor Temperature
+	#
+	label	temp3		"CPU"
+	set	temp3_max	80		# from BIOS (IDU = 87)
+	set	temp3_max_hyst	75		# from BIOS
+
+	#
+	# PCH Temperature
+	#
+	label	temp4		"PCH"
+
+And the second one is for  new BIOS versions:
+
+################################################################################
+#
+#
+#	lm_sensors configuration for Intel DQ67SW (with newer BIOS)
+#
+#	NOTES:
+#
+#		Temperature input mappings were changed by a BIOS update
+#		between SWQ6710H.86A.0050.2011.0401.1409 (01-Apr-2011) and
+#		SWQ6710H.86A.0065.2012.0917.1519 (17-Sep-2012).
+#
+#		Minimum and maximum values are the defaults from BIOS version
+#		SWQ6710H.86A.0065.2012.0917.1519 (17-Sep-2012).
+#
+#		Intel Desktop Utilities 3.2.3.052 appears to get its default
+#		values from the BIOS.
+#
+#		"FRONT" and "REAR" fan labels correspond to the motherboard
+#		headers, but not necessarily the actual fan locations.
+#
+#		Minimum fan RPMs should be adjusted to reflect the behavior of
+#		the installed fans.
+#
+#		"Memory DIMM Temperature" is presumably measured by a diode
+#		somewhere in the vicinity of the DIMM slots; "System Temperature
+#		might be a better name.  If this is correct, 90 degrees seems
+#		like an extremely high threshhold for this reading.
+#
+#		All hysteresis values are set to 75 degrees, which seems to be
+#		the default for the chip/driver.
+#
+#
+################################################################################
+
+chip "nct6775-*"
+
+	ignore	cpu0_vid
+
+	########################################################################
+	#
+	#	Voltages
+	#
+	########################################################################
+
+	#
+	# Processor Vcc
+	#
+	label	in0		"VCORE"
+	set	in0_min		0.2
+	set	in0_max		1.6
+
+	#
+	# +12 Volts
+	#
+	label	in1		"+12V"
+	compute	in1		16*@, @/16
+	set	in1_min		10.8
+	set	in1_max		13.2
+
+	#
+	# AVCC(?) - Not shown in BIOS or IDU; min/max taken from +3.3V
+	#
+	label	in2		"AVCC"
+	set	in2_min		3.1
+	set	in2_max		3.5
+
+	#
+	# +3.3 Volts
+	#
+	label	in3		"+3.3V"
+	set	in3_min		3.1
+	set	in3_max		3.5
+
+	#
+	# +5 Volts
+	#
+	label	in4		"+5V"
+	compute	in4		4*@, @/4
+	set	in4_min		4.7
+	set	in4_max		5.3
+
+	#
+	# Memory Vcc
+	#
+	label	in5		"+1.5V"
+	set	in5_min		1.4
+	set	in5_max		1.6
+
+	#
+	# PCH Vcc
+	#
+	label	in6		"PCH"
+	set	in6_min		0.6
+	set	in6_max		1.6
+
+	#
+	# +3.3 Volt Standby
+	#
+	label	in7		"VSB"
+	set	in7_min		3.0
+	set	in7_max		3.6
+
+	#
+	# VBAT(?) - Not shown in BIOS or IDU; min/max taken from old BIOS
+	#
+	label	in8		"VBAT"
+	#set	in8_min		2.7
+	#set	in8_max		3.3
+
+	########################################################################
+	#
+	#	Fans
+	#
+	########################################################################
+
+	ignore	fan4
+
+	#
+	# Chassis Inlet Fan
+	#
+	label	fan1		"FRONT"
+	set	fan1_min	250		# from IDU (BIOS does not set)
+
+	#
+	# Processor Fan
+	#
+	label	fan2		"CPU"
+	set	fan2_min	250		# from IDU (BIOS does not set)
+
+	#
+	# Chassis Outlet Fan
+	#
+	label	fan3		"REAR"
+	set	fan3_min	250		# from IDU (BIOS does not set)
+
+	########################################################################
+	#
+	#	Temperatures
+	#
+	########################################################################
+
+	ignore	temp3
+	ignore	temp8
+
+	#
+	# Memory DIMM Temperature
+	#
+	label	temp1		"DIMM"
+	set	temp1_max	90
+	set	temp1_max_hyst	75
+
+	#
+	# VR Temperature
+	#
+	label	temp2		"VR"
+	set	temp2_max	90
+	set	temp2_max_hyst	75
+
+	#
+	# Processor Temperature
+	#
+	label	temp6		"CPU"
+	set	temp6_max	99
+	set	temp6_max_hyst	75
+
+	#
+	# PCH Temperature
+	#
+	label	temp7		"PCH"
+	set	temp7_max	114
+	set	temp7_max_hyst	75

--- a/configs/Jetway/NC92-330-LF.conf
+++ b/configs/Jetway/NC92-330-LF.conf
@@ -1,0 +1,75 @@
+# Configuration contributed by Maciej Żenczykowski.
+# Kernel modules used: f71882fg, coretemp.
+
+
+# Jetway NC92-330-LF
+
+chip "f71862fg-*"
+
+    label in0 "Vcc3V"
+    label in1 "Vcore"
+    label in2 "   NB"
+    label in3 "+ 5V"
+    label in4 "+12V"
+    label in5 "5VSB"
+    label in6 "VDIMM"
+    label in7 "VSB3V"
+    label in8 "Vbat"
+
+    label fan1 "CPUFAN"
+    label fan2 "SYSFAN1"
+    label fan3 "SYSFAN2"
+
+    label temp1 "?CPU Temp"
+    label temp2 "?Sys Temp"
+    label temp3 "???? Temp"
+
+# According to datasheet, 3VCC/VSB/VBAT
+# (ie. Vcc3V/VSB3V/Vbat, or in0/in7/in8)
+# use internal R1=R2=150K Ohm resistors
+#
+# remember V_in_to_chip = V_real * R2 / (R1 + R2)
+# (where V_real----R1---*----V_in_to_chip) [max 2.048V]
+# (                     |                )
+# (                    R2                )
+# (                     |                )
+# (                    GND               )
+#
+# It would seem that VDIMM is the same...
+# Hence those four are set to use "@*2, @/2"
+#
+# The values of 5.25 for +5V and 5VSB and 11 for +12V
+# are from the datasheet as well (after juggling):
+#
+# VCORE    R1=1K   R2=inf VCORE  -> *1
+# VRAM     R1=10K  R2=10K VIN2   -> *2
+# VCHIPSET R1=4.7K R2=10K VIN3   -> *1.47
+# VCC5V    R1=20K  R2=4.7 VIN4   -> *5.255319148
+# +12V     R1=200K R2=20K VIN5   -> *11
+# VCC1.5V  R1=10K  R2=inf VIN6   -> *1
+
+    compute in0 @*2, @/2
+    compute in1 @, @
+    compute in2 @, @
+    compute in3 @*5.255319148, @/5.255319148
+    compute in4 @*11, @/11
+    compute in5 @*5.255319148, @/5.255319148
+    compute in6 @*2, @/2
+    compute in7 @*2, @/2
+    compute in8 @*2, @/2
+
+#   set temp1_type 2
+    set temp1_max        85
+    set temp1_max_hyst   81
+    set temp1_crit       65
+#   set temp1_crit_hyst  61
+#   set temp2_type 2
+    set temp2_max        85
+    set temp2_max_hyst   81
+    set temp2_crit      100
+#   set temp2_crit_hyst  96
+#   set temp3_type 2
+    set temp3_max        70
+    set temp3_max_hyst   68
+    set temp3_crit       85
+#   set temp3_crit_hyst  83

--- a/configs/Kontron/986LCD-M.conf
+++ b/configs/Kontron/986LCD-M.conf
@@ -1,0 +1,48 @@
+# Voltage section for the Kontron 986LCD-M:
+
+chip "w83627thf-*"
+
+# Voltages
+
+    label in0  "Vcore"
+    label in1  "+12V"
+    label in2  "+3.3V"
+    label in3  "+5V"
+    label in4  "+1.5V"
+    label in7  "5VSB"
+    label in8  "Vbat"
+
+    # External resistors
+    compute in1  @ * (1 + 10/3.57), @ / (1 + 10/3.57)
+    # Internal resistors
+    compute in3  @ * (1 + 34/51), @ / (1 + 34/51)
+    compute in7  @ * (1 + 34/51), @ / (1 + 34/51)
+
+    set in1_min  12.0 * 0.95
+    set in1_max  12.0 * 1.05
+    set in2_min   3.3 * 0.95
+    set in2_max   3.3 * 1.05
+    set in3_min   5.0 * 0.95
+    set in3_max   5.0 * 1.05
+    set in4_min   1.5 * 0.95
+    set in4_max   1.5 * 1.05
+    set in7_min   5.0 * 0.90
+    set in7_max   5.0 * 1.10
+    set in8_min   3.0 * 0.90
+    set in8_max   3.0 * 1.15
+
+# Fans
+
+    label fan1  "Sys Fan"
+    label fan2  "CPU Fan"
+    label fan3  "Aux Fan"
+
+# Temperatures
+
+   label temp1 "M/B Temp"
+   label temp2 "CPU Temp"
+   # temp3 is an optional external sensor
+
+   # Default limits for temp2 and temp3 are sane, but not for temp1
+   set temp1_max       80
+   set temp1_max_hyst  75

--- a/configs/MSI/945P-Neo2-F.conf
+++ b/configs/MSI/945P-Neo2-F.conf
@@ -1,0 +1,56 @@
+# Winbond W83627EHF configuration contributed by Dmitry Pechnikov
+# This is for an MSI 945P Neo2-F aka MS-7176.
+chip "w83627ehf-*" "w83627dhg-*"
+
+    label in0 "VCore"
+    label in1 "+12V"
+    label in2 "AVCC"
+    label in3 "3VCC"
+    label in6 "+5V"
+    label in7 "VSB"
+    label in8 "VBAT"
+
+# +12V is in1 and +5V is in6 as recommended by datasheet
+    compute in1 @*(1+(56/10)),  @/(1+(56/10))
+    compute in6 @*(1+(22/10)),  @/(1+(22/10))
+     
+    set in1_min   12.0*0.9
+    set in1_max   12.0*1.1
+    set in6_min   5.0*0.9
+    set in6_max   5.0*1.1
+
+    set in2_min   3.3*0.9
+    set in2_max   3.3*1.1
+    set in3_min   3.3*0.9
+    set in3_max   3.3*1.1
+    set in7_min   3.3*0.9
+    set in7_max   3.3*1.1
+    set in8_min   3.3*0.9
+    set in8_max   3.3*1.1
+
+    ignore in4
+    ignore in5
+    ignore in9
+
+# Fans
+    label fan1      "Case Fan"
+    label fan2      "CPU Fan"
+    label fan3      "Aux Fan"
+   
+    ignore fan1
+    ignore fan3
+    ignore fan5
+#   set fan1_min    1200
+    set fan2_min    1000
+
+# Temperatures
+    label temp1     "Sys Temp"
+    label temp2     "CPU Temp"
+    label temp3     "AUX Temp"
+
+    set temp1_max       55
+    set temp1_max_hyst  48
+    set temp2_max       55
+    set temp2_max_hyst  47
+    set temp3_max       55
+    set temp3_max_hyst  50

--- a/configs/MSI/975X-Platinum.conf
+++ b/configs/MSI/975X-Platinum.conf
@@ -1,0 +1,63 @@
+# Configuration file for the MSI 975X Platinum (MS-7246),
+# contributed by Leonardo Marín.
+
+
+chip "w83627ehf-*" "w83627dhg-*"
+
+ label in0 "VCore" # CPU Core Voltage
+ label in1 "VPCIEx" # PCI Express Voltage
+ label in2 "AVCC"
+ label in3 "3VCC"
+ label in6 "+ 5V" # +5V, or so i think
+ label in7 "3VSB"
+ label in8 "VBAT"
+ label in9 "+12V" # +12V, or so i think
+
+## +12V is in9 and +5V is in6 ##
+ compute in9 @*(1+(56/10)), @/(1+(56/10))
+ compute in6 @*(1+(22/10)), @/(1+(22/10))
+
+ set in9_min 12.0*0.9
+ set in9_max 12.0*1.1
+ set in6_min 5.0*0.9
+ set in6_max 5.0*1.1
+
+ set in0_min 0.9
+ set in0_max 1.7
+ set in1_min 1.4
+ set in1_max 2.0
+ set in2_min 3.3*0.9
+ set in2_max 3.3*1.1
+ set in3_min 3.3*0.9
+ set in3_max 3.3*1.1
+ set in7_min 3.3*0.9
+ set in7_max 3.3*1.1
+ set in8_min 3.0*0.9
+ set in8_max 3.3*1.1
+
+ ignore in4
+ ignore in5
+
+## Temperatures ##
+
+ label temp1 "Sys Temp"
+ label temp2 "CPU Temp"
+ label temp3 "Aux Temp"
+
+ set temp1_max 55
+ set temp1_max_hyst 48
+ set temp2_max 55
+ set temp2_max_hyst 47
+ set temp3_max 55
+ set temp3_max_hyst 50
+
+## Fans ##
+
+ label fan1 "PSU Fan"
+ label fan2 "CPU Fan"
+ label fan3 "NB Fan"
+ label fan4 "Sys Fan"
+
+ set fan2_min 800
+
+ ignore fan5

--- a/configs/MSI/GF615M-P33.conf
+++ b/configs/MSI/GF615M-P33.conf
@@ -1,0 +1,60 @@
+# Contributed by John Smith.
+
+
+# lm_sensors configuration file for the MSI GF615M-P33 rev 1.3 (MS-7597)
+# 2011-07-14, Kid from Belgrade
+# tweaked from config for MSI P35 Neo / MSI MS-7360 motherboard
+# 2007-09-21, Andre Jagusch
+# Comments welcome!
+
+chip "f71889ed-*"
+
+# Temperature
+    label temp1       "CPU"
+    label temp2       "System"
+    ignore temp3
+
+# Fans
+    label fan1        "CPU"
+    label fan2        "System"
+    label fan3        "Misc"
+
+# sensors in2, in3, in6, in7 and in8  may be ignored since
+# they are not shown in BIOS for MS-7597
+# in6 is always 0.00
+# Voltage
+    label in0         "+3.3V"
+    label in1         "Vcore"
+#    ignore in2
+#    ignore in3
+    label in2         "Vdimm"
+    label in3         "Vchip"
+    label in4         "+5V"
+    label in5         "+12V"
+    ignore in6
+#    ignore in7
+#    ignore in8
+    label in7         "3VSB"
+    label in8         "Battery"
+
+# never change the in0, in7 and in8 compute, these are hardwired in the chip!
+# +5V, +12V and +3.3V computes looking fine for MS-7597, nothing changed
+    compute in0       (@ * 2), (@ / 2)
+    compute in2       (@ * 2), (@ / 2)
+    compute in3       (@ * 2), (@ / 2)
+    compute in4       (@ * 5.25), (@ / 5.25)
+    compute in5       (@ * 11), (@ / 11)
+    compute in6       (@ * 6.585), (@ / 6.585)
+    compute in7       (@ * 2), (@ / 2)
+    compute in8       (@ * 2), (@ / 2)
+
+
+# On Fintek, first sensor is below or near the CPU socket (how to determine this?)
+# CPU temperature is also measurable by on-die sensor on K10 series.
+# Now I have not found this anywhere and correction is correlated with Fintek,
+# tweaked for Athlon II x2 250, may differ for others.
+chip "k10temp-*"
+
+   label temp1 "CPU K10 Temp"
+
+   compute temp1 (@ + 5.5), (@ - 5.5)

--- a/configs/MSI/IM-945GC.conf
+++ b/configs/MSI/IM-945GC.conf
@@ -1,0 +1,58 @@
+# Configuration file contributed by Bryan Guidroz.
+
+
+chip "f71882fg-isa-0a10"
+
+# Ignore - Voltage
+# The F71882FG uses an 8-bit, 8 mV LSB ADC for voltage monitoring.
+# This means that it can measure up to 2.04 V directly. This is the value
+# of in2, in3 and in6 on the MSI MS-9832, which means these inputs
+# are saturated. This means these inputs are unused.
+
+   ignore in2
+   ignore in3
+   ignore in6
+
+# Ignore - Fans
+# The MSI MS-9832 uses fan1 (CPU Fan) and fan2 (System Fan).
+# This means other fans are unused.
+
+   ignore fan3
+   ignore fan4
+
+# Ignore - Temps
+# The MSI MS-9832 uses temp1 (CPU temp) and temp3 (System temp).
+# This means temp2 is unused.
+
+   ignore temp2
+
+# Other - Voltages
+# in0 (+3.3v), in7 (3VSB), and in8 (Vbat) are internally monitored voltages
+# with internal dividers. This means the values are properly set and do not
+# need to be defined in this configuration as they should be reported properly.
+
+# Voltages
+   label in1 "Vcore"
+   label in4 "+5V"
+   label in5 "+12V"
+
+   compute in4  @*(1+200/47),  @/(1+200/47)
+   compute in5  @*(1+200/20),  @/(1+200/20)
+
+   set in1_max  1.1625 * 1.05
+
+# Fans
+   label fan1 "CPU Fan"
+   label fan2 "Sys Fan"
+
+   set fan1_min 2100
+   set fan2_min 1400
+
+# Temperatures
+   label temp1 "CPU Temp"
+   label temp3 "Sys Temp"
+
+   set temp1_max       60
+   set temp1_max_hyst  58
+   set temp3_max       50
+   set temp3_max_hyst  48

--- a/configs/MSI/IM-945GSE-A.conf
+++ b/configs/MSI/IM-945GSE-A.conf
@@ -1,0 +1,39 @@
+# lm_sensors configuration file for the MSI IM-945GSE-A motherboard
+# Atom N270, Dual Gigabit Intel 82574L controllers, VGA, DVI
+# 2009-07-01 Thomas Ettwein
+# 2010-08-29 Leo Krueger
+
+chip "f71882fg-*"
+
+# Temperature
+     label temp1       "CPU"
+     label temp2       "Systemboard"
+     ignore temp3
+
+# Fans
+      ignore fan1 # no connector on board
+      label fan2 "CPUFAN1"
+      ignore fan3 # no connector on board
+      ignore fan4 # no connector on board
+
+
+# Voltage
+     label in0         "3.3V"
+     label in1         "Vcore"
+     label in2         "Vdimm"
+     label in3         "Vchip"
+     label in4         "+5V"
+     label in5         "12V"
+     label in6         "5VSB"
+     label in7         "3VSB"
+     label in8         "Battery"
+
+# never change the in0, in7 and in8 compute, these are hardwired in the chip!
+     compute in0       (@ * 2), (@ / 2)
+     compute in2       (@ * 2), (@ / 2)
+     compute in3       (@ * 2), (@ / 2)
+     compute in4       (@ * 5.25), (@ / 5.25)
+     compute in5       (@ * 11.0), (@ / 11.0)
+     compute in6       (@ * 5.25), (@ / 5.25)
+     compute in7       (@ * 2), (@ / 2)
+     compute in8       (@ * 2), (@ / 2)

--- a/configs/MSI/P35-Neo.conf
+++ b/configs/MSI/P35-Neo.conf
@@ -1,0 +1,37 @@
+# lm_sensors configuration file for the MSI P35 Neo / MSI MS-7360 motherboard
+# 2007-09-21, Andre Jagusch
+# Comments welcome!
+
+chip "f71882fg-*"
+
+# Temperature
+    label temp1       "CPU"
+    label temp2       "System"
+    ignore temp3
+
+# Fans
+    label fan1        "CPU"
+    label fan2        "System"
+    label fan3        "Power"
+    label fan4        "Aux"
+
+# Voltage
+    label in0         "3.3V"
+    label in1         "Vcore"
+    label in2         "Vdimm"
+    label in3         "Vchip"
+    label in4         "+5V"
+    label in5         "12V"
+    label in6         "5VSB"
+    label in7         "3VSB"
+    label in8         "Battery"
+
+# never change the in0, in7 and in8 compute, these are hardwired in the chip!
+    compute in0       (@ * 2), (@ / 2)
+    compute in2       (@ * 2), (@ / 2)
+    compute in3       (@ * 2), (@ / 2)
+    compute in4       (@ * 5.25), (@ / 5.25)
+    compute in5       (@ * 11), (@ / 11)
+    compute in6       (@ * 6.585), (@ / 6.585)
+    compute in7       (@ * 2), (@ / 2)
+    compute in8       (@ * 2), (@ / 2)

--- a/configs/MSI/P6N-SLI-FI.conf
+++ b/configs/MSI/P6N-SLI-FI.conf
@@ -1,0 +1,58 @@
+# Sasha Alexandr - grapefruitgirl at linuxmail dot org 
+# Sept 2007 - lm_sensors 2.10.4 
+# Platform: MS-7350-010  P6N-SLI-FI  mfg-date: 0707
+# Chipset: nVidia nforce2 650i/430i SLI
+# CPU: Intel CORE2 E2160 1.8 Ghz
+# BIOS: AMIBIOS v2.3
+#
+# Configuration for Fintek F71882FG Super-I/O device & coretemp driver for CORE2 CPU temps:
+
+  chip "f71882fg-isa-0a00"
+
+# NOTE: Fans 1 and 3 are switched around (somewhere).
+   label fan1 "CPU Cooler"
+   label fan2 "SysFan2: Rear Case"
+   label fan3 "SysFan1: some device"
+   label fan4 "SysFan3: some device"
+
+# NOTE: Set statements for fans & volts give an 'Unknown Feature' error currently. This should be fixed sometime.
+# The fans report exact same as BIOS; no computing needed.
+# Header labeled 'Sysfan3' on board doesn't seem to report RPM.
+
+   label temp1 "CPU Temp"
+   label temp2 "System Temp"
+   label temp3 "128 ignore"
+
+#  NOTE: temp1 reports 5'C less than BIOS so I add 5'C to it.
+   compute temp1 (@ + 5), (@ - 5)
+   ignore  temp3
+
+# Voltages:
+   label in0 "3.3V in0"
+   label in1 "CPU V-Core in1"
+   label in2 "+5V StBy in2"
+   label in3 "V-Dimm in3"
+   label in4 "+5V in4"
+   label in5 "+12V in5"
+   label in6 "0.888 ignore"
+   label in7 "3.3 V StBy in7"
+   label in8 "3V Battery in8"
+
+   compute in0  (@ * 2.00) ,(@ / 2.00)
+#  compute in1  (no computing necessary)
+   compute in2  (@ * 5.25) ,(@ / 5.25)
+   compute in3  (@ * 2.50) ,(@ / 2.50)
+#  NOTE: I add 0.005 to in4 so it reads EXACTLY as BIOS reads.
+   compute in4  (0.005 + @ * 5.25) ,(0.005 - @ / 5.25)
+   compute in5  (@ * 11.00),(@ / 11.00)
+   ignore  in6
+   compute in7  (@ * 2.00) ,(@ / 2.00)
+   compute in8  (@ * 2.00) ,(@ / 2.00)
+
+chip "coretemp-isa-0000"
+label temp1 "Core 0 Temp"
+
+chip "coretemp-isa-0001"
+label temp1 "Core 1 Temp"
+
+# EOF

--- a/configs/MSI/P965-Platinum.conf
+++ b/configs/MSI/P965-Platinum.conf
@@ -1,0 +1,48 @@
+# Configuration file contributed by Olaf Mandel.
+
+
+# configuration for the Fintek f71882fg as used on the MSI X58 Pro-E (MS-7522)
+chip "f71882fg-*"
+
+# Temperature
+    label   temp1 "CPU"
+    label   temp2 "IOH"
+    label   temp3 "System"
+
+# Fans
+    label   fan1  "CPU"
+    label   fan2  "System 1" # This is not confirmed
+    label   fan3  "System 2"
+    ignore  fan2
+    ignore  fan4
+
+# Voltage
+    label   in0   "3.3V"
+    label   in1   "Vcore"
+    ignore  in2
+    ignore  in3
+    label   in4   "5V"
+    label   in5   "12V"
+    ignore  in6
+    label   in7   "3VSB"
+    label   in8   "Vbat"
+    compute in0   (@ * 2), (@ / 2) # Hardwired in chip, don't change
+    compute in4   (@ * 5.25), (@ / 5.25) # E24: (12 + 51) / 12
+    compute in5   (@ * 11), (@ / 11)     # E6:  ( 1 + 10) /  1
+    compute in7   (@ * 2), (@ / 2) # Hardwired in chip, don't change
+    compute in8   (@ * 2), (@ / 2) # Hardwired in chip, don't change
+
+# Thresholds
+    set in1_max           1.3
+    set temp1_max        85
+    set temp1_max_hyst   82
+    set temp1_crit      100
+    set temp1_crit_hyst  97
+    set temp2_max        75
+    set temp2_max_hyst   72
+    set temp2_crit       85
+    set temp2_crit_hyst  82
+    set temp3_max        55
+    set temp3_max_hyst   52
+    set temp3_crit       65
+    set temp3_crit_hyst  62

--- a/configs/MSI/X58-Pro-E.conf
+++ b/configs/MSI/X58-Pro-E.conf
@@ -1,0 +1,48 @@
+# Configuration file contributed by Olaf Mandel.
+
+
+# configuration for the Fintek f71882fg as used on the MSI X58 Pro-E (MS-7522)
+chip "f71882fg-*"
+
+# Temperature
+    label   temp1 "CPU"
+    label   temp2 "IOH"
+    label   temp3 "System"
+
+# Fans
+    label   fan1  "CPU"
+    label   fan2  "System 1" # This is not confirmed
+    label   fan3  "System 2"
+    ignore  fan2
+    ignore  fan4
+
+# Voltage
+    label   in0   "3.3V"
+    label   in1   "Vcore"
+    ignore  in2
+    ignore  in3
+    label   in4   "5V"
+    label   in5   "12V"
+    ignore  in6
+    label   in7   "3VSB"
+    label   in8   "Vbat"
+    compute in0   (@ * 2), (@ / 2) # Hardwired in chip, don't change
+    compute in4   (@ * 5.25), (@ / 5.25) # E24: (12 + 51) / 12
+    compute in5   (@ * 11), (@ / 11)     # E6:  ( 1 + 10) /  1
+    compute in7   (@ * 2), (@ / 2) # Hardwired in chip, don't change
+    compute in8   (@ * 2), (@ / 2) # Hardwired in chip, don't change
+
+# Thresholds
+    set in1_max           1.3
+    set temp1_max        85
+    set temp1_max_hyst   82
+    set temp1_crit      100
+    set temp1_crit_hyst  97
+    set temp2_max        75
+    set temp2_max_hyst   72
+    set temp2_crit       85
+    set temp2_crit_hyst  82
+    set temp3_max        55
+    set temp3_max_hyst   52
+    set temp3_crit       65
+    set temp3_crit_hyst  62

--- a/configs/PCchips/M811.conf
+++ b/configs/PCchips/M811.conf
@@ -1,0 +1,97 @@
+# lm_sensors configuration file for the PCchips M811 motherboard
+
+# 2006-05-30, Hans de Goede <j.w.r.degoede@hhs.nl>
+
+# Comments welcome!
+
+
+
+chip "it87-*"
+
+
+
+# Voltage monitors as advised in the It8705 data sheet
+
+
+
+    label in0 "VCore"
+
+    label in1 "+2.5V"
+
+    label in2 "+3.3V"
+
+    label in8 "VBat" 
+
+    # 5, 12, -5, -12 and standby do not seem to be connected
+
+    ignore in3
+
+    ignore in4
+
+    ignore in5
+
+    ignore in6
+
+    ignore in7
+
+    # The It8705 doesn't monitor vid
+
+    ignore vid
+
+
+
+    # in0 will depend on your processor VID value, set to voltage specified in
+
+    # bios
+
+    set in0_min 1.4 * 0.95
+
+    set in0_max 1.4 * 1.05
+
+    set in1_min 2.4
+
+    set in1_max 2.6
+
+    set in2_min 3.3 * 0.95
+
+    set in2_max 3.3 * 1.05
+
+    #the chip does not support in8 min/max
+
+
+
+# Temperature
+
+
+
+    label temp2       "CPU Temp"
+
+    set   temp2_over  50
+
+    set   temp2_low   15
+
+    label temp3       "PWM Temp?"
+
+    set   temp3_over  65
+
+    set   temp3_low   15
+
+    # temp1 does not seem to be connected
+
+    ignore temp1
+
+
+
+# Fans
+
+    label fan1        "CPU fan"
+
+    label fan2        "SYS fan"
+
+    set fan1_min      3000
+
+    # The system fan is not always connected
+
+    set fan2_min      0
+
+    ignore fan3

--- a/configs/Sapphire/PureFusionMiniE350.conf
+++ b/configs/Sapphire/PureFusionMiniE350.conf
@@ -1,0 +1,31 @@
+# Contributed by tux99.
+
+
+chip "f71808e-*"
+
+   label  in0  "VCC  +3.3V"
+   # E-350 Vcore range is ~ 0.5V-1.35V (lowest idle state to max load)
+   label  in1  "CPU  Vcore"
+   ignore in2
+   label  in3  "DDR3 VDIMM"
+   label  in4  "FCH  +1.1V"
+   label  in5  "PCIe +1.8V"
+   label  in7  "3VSB +3.3V"
+   label  in8  "VBAT +3.0V"
+
+   compute in0  @*2, @/2
+   compute in3 (@ * 1.465), (@ / 1.465)
+   compute in7  @*2, @/2
+   compute in8  @*2, @/2
+
+   label fan1 "CPU Fan"
+   label fan2 "SYS Fan"
+
+   ignore fan3
+
+   label  temp1 "SYS Temp1"
+   label  temp2 "SYS Temp2"
+
+chip "k10temp-*"
+
+  label temp1 "CPU Temp"

--- a/configs/Shuttle/XPC-SG33G5M-Deluxe.conf
+++ b/configs/Shuttle/XPC-SG33G5M-Deluxe.conf
@@ -1,0 +1,57 @@
+# lm_sensors 3 configuration file for the "Shuttle XPC SG33G5M Deluxe"
+# 2008-09-26, Matthieu Crapet <mcrapet@gmail.com>
+# Comments welcome!
+
+
+##
+# Chip 'ITE IT8718F Super IO Sensors' (it87.ko)
+##
+chip "it8718-*"
+
+#
+# Voltages (cpu0_vid, in0, ..., in8)
+#
+set in2_min  3.3 * 0.95
+set in2_max  3.3 * 1.05
+set in3_min    5 * 0.95
+set in3_max    5 * 1.05
+set in4_min   12 * 0.95
+set in4_max   12 * 1.05
+set in7_min    5 * 0.95
+set in7_max    5 * 1.05
+
+label in0 "CPU voltage"
+label in1 "Chipset voltage"
+label in2 "+3.3V"
+label in3 "+5V"
+label in4 "+12V"
+label in6 "DDR2 voltage"
+label in7 "+5VSB"
+label in8 "Battery voltage"
+
+ignore in5
+compute in3  ((6.8/10)+1)*@ , @/((6.8/10)+1)
+compute in4  ((30/10)+1)*@  , @/((30/10)+1)
+compute in7  ((6.8/10)+1)*@ , @/((6.8/10)+1)
+
+#
+# Fans (fan1, fan2, fan3)
+#
+set fan1_min 700
+label fan1  "System Fan"
+
+ignore fan2
+ignore fan3
+
+#
+# Temperature (temp1, temp2, temp3)
+#
+set   temp1_max 60
+set   temp1_min 15
+label temp1  "CPU Temp"
+
+set   temp2_max 65
+set   temp2_min 15
+label temp2  "M/B Temp"
+
+ignore temp3

--- a/configs/SuperMicro/C2SBE.conf
+++ b/configs/SuperMicro/C2SBE.conf
@@ -1,0 +1,92 @@
+# Example configuration for the SuperMicro C2SBE.
+# Contributed by Romain Dolbeau.
+
+# The C2SBA is similar to the C2SBE (only with video on-board).
+
+
+# settings for the supermicro C2SBE
+# Originally written by Romain Dolbeau <romain@dolbeau.org>
+# Uses at your own risk !
+#
+# Here's the info as supplied by Supermicro:
+#
+# Bus Type = ISAIO
+# One W83627DHG
+#
+# Windbond W83627DHG, IndexReg=295, DataReg=296
+# =============================================================
+# Fan1/CPU Fan Speed, Bank 0, Offset 0x29		RPM = 1350000/8/Data
+# Fan2 Fan Speed, Bank 5, Offset 0x53		RPM = 1350000/8/Data
+# Fan3 Fan Speed, Bank 0, Offset 0x28		RPM = 1350000/8/Data
+# Fan4 Fan Speed, Bank 0, Offset 0x3f		RPM = 1350000/8/Data
+# Fan5 Fan Speed, Bank 0, Offset 0x2a		RPM = 1350000/8/Data
+# CPU Voltage, Bank 0, Offset 0x20		Voltage = Data* 0.008
+# -12V Voltage, Bank 0, Offset 0x26		Voltage =((Data*0.008-2.048)/(10./242.))+2.048
+# +12V Voltage, Bank 0, Offset 0x21		Voltage = Data* 0.008/(10./160.)
+# +3.3V Voltage, Bank 0, Offset 0x22		Voltage = Data* 0.016
+# DIMM Voltage, Bank 0, Offset 0x24		Voltage = Data* 0.008
+# +5V Voltage, Bank 0, Offset 0x25		Voltage = Data* 0.008/(10./40.)
+# +3.3VSb Voltage, Bank 5, Offset 0x50		Voltage = Data* 0.016
+# Battery Voltage, Bank 5, Offset 0x51		Voltage = Data* 0.016
+# CPU Temperature, Bank 1, Offset 0x50		Temperature = Data
+# System Temperature, Bank 0, Offset 0x27		Temperature = Data
+# Chassis Intrusion, Bank 0, Offset 0x42, BitMask 0x10	1 = Bad, 0 = Good
+#			(Clear Bit: Bank 0, Offset 0x46, BitMask 0x80)
+
+chip "w83627dhg-*"
+# Voltages ; note that in the table above, the .008 and .016 factors are
+# already computed in the driver...
+    label in0 "VCore"
+    label in1 "+12V"
+    label in2 "+3.3V"
+    ignore in3
+    label in4 "DIMM Voltage"
+    label in5 "+5V"
+    label in6 "-12V"
+    label in7 "+3.3VSB"
+    label in8 "VBAT"
+
+# CPU Voltage limits are probably CPU-dependant
+    compute in0 @, @
+    set in0_min 1.0
+    set in0_max 1.4
+    compute in1 @*16,  @/16
+    set in1_min 12*0.95
+    set in1_max 12*1.05
+    compute in2 @, @
+    set in2_min 3.3*0.95
+    set in2_max 3.3*1.05
+#   compute in3 @, @
+# DIMM Voltage limits ???
+    compute in4 @, @
+    set in4_min 1.8*0.95
+    set in4_max 1.8*1.05
+    compute in5 @*4, @/4
+    set in5_min 5*0.95
+    set in5_max 5*1.05
+    compute in6 ((@-2.048)*24.2)+2.048, ((@-2.048)/24.2)+2.048
+    set in6_min -12*1.05
+    set in6_max -12*0.95
+    compute in7 @, @
+    set in7_min 3.3*0.95
+    set in7_max 3.3*1.05
+# VBAT Voltage limits ???
+    compute in8 @, @
+    set in8_min 3*0.9
+    set in8_max 3*1.1
+
+# Fans ; default in the driver is fine
+# you should ignore the unplugged ones
+   label fan1      "Fan 3"
+   label fan2      "Fan1/CPU Fan"
+   label fan3      "Fan 5"
+   label fan4      "Fan 4"
+   label fan5      "Fan 2"
+
+# Temperatures
+# Min and Max are environment-dependant
+   label temp1     "System Temp"
+   set temp1_max 45
+   label temp2     "CPU Temp"
+   set temp2_max 65
+   ignore temp3

--- a/configs/SuperMicro/C7H61.conf
+++ b/configs/SuperMicro/C7H61.conf
@@ -1,0 +1,73 @@
+#
+# Libsensors configuration for SuperMicro C7H61-O and C7H61-L boards.
+# 
+# C7H61-L has a single nct6776 sensor chip.
+# C7H61-O has two sensor chips, nct6776 and nct6106. nct6106 is not used
+# for temperature, fans or voltage sensing. Hardware monitoring for this
+# chip is not enabled, and you should not enable it.
+# BIOS allows one to set nct6776 parameters, such as voltage or PWM fan
+# control and default strategy.
+#
+
+chip "nct6776-isa-0a30"
+
+    label in0 "Vcore"
+    label in1 "+12V"
+    label in2 "AVCC"
+    label in3 "+3.3V"
+    label in4 "VDIMM"
+    label in5 "+5V"
+    label in6 "VTT_CPU"
+    label in7 "3VSB"
+    label in8 "Vbat"
+
+    compute in1   @*6.6, @/6.6
+    compute in5   @*4, @/4
+
+    # min/max values are set by the BIOS
+
+    ignore fan1
+    label fan2 "System FAN4"
+    label fan3 "CPU Fan"
+    label fan4 "System FAN2"
+    label fan5 "System FAN3"
+
+    ignore temp7
+    ignore temp8
+    ignore temp9
+    ignore temp10
+
+    ignore intrusion1
+
+
+chip "nct6106-*"
+
+    ignore in0
+    ignore in1
+    label in2 "AVCC"
+    label in3 "+3.3V"
+    ignore in4
+    ignore in5
+    ignore in6
+    label in7 "Vbat"
+    ignore in8
+
+    set in2_min  3.3 * 0.90
+    set in2_max  3.3 * 1.10
+    set in3_min  3.3 * 0.90
+    set in3_max  3.3 * 1.10
+    set in7_min  3.3 * 0.90
+    set in7_max  3.3 * 1.10
+
+    ignore fan1
+    ignore fan2
+    ignore fan3
+
+    ignore temp1
+    ignore temp2
+    ignore temp3
+    ignore temp7
+    ignore temp8
+    ignore temp9
+
+    ignore intrusion0

--- a/configs/SuperMicro/C7X58.conf
+++ b/configs/SuperMicro/C7X58.conf
@@ -1,0 +1,66 @@
+# Contributed by Henrique de Moraes Holschuh.
+
+# Also compatible with X8SAX.
+
+
+#
+# Libsensors configuration for SuperMicro C7X58 and X8SAX boards, revision 1.1 or 2.0
+# Scaling factors kindly provided by SuperMicro support.
+# 
+# Board has two sensor chips, w83627dhg is not used for temperature,
+# fans or voltage sensing. sensors-detect will suggest that you load the
+# w83627ehf driver but you shouldn't.
+# BIOS allows one to set w83795adg parameters, such as voltage or PWM fan
+# control and default strategy.
+#
+
+chip "w83795adg-*"
+
+   label fan1 "CPU Fan"
+
+   label in0  "CPU Core"
+   label in2  "DIMM"
+   label in3  "+5V"
+   label in4  "+12V"
+   label in5  "-12V"
+   label in11 "VTT"
+   label in12 "+3.3V"
+   label in13 "+3.3Vsb"
+   label in14 "Vbatt"
+
+   # The BIOS does not set the correct limits for VTT, but it is wired.
+   # Default to broad limits used on Asus boards, feel free to refine for your CPU.
+   set in11_min 0.770
+   set in11_max 1.538
+
+   label temp6 "System temperature"
+   label temp7 "CPU temperature"
+
+   compute in3 @*4, @/4
+   compute in4 @*6.62, @/6.62
+   compute in5 (@-2.048)*24.2 + 2.048, (@-2.048)/24.2 + 2.048
+
+chip "w83627dhg-*"
+
+# SuperIO chip used only for the FDC, UARTs and GPIO
+# SENSORS ARE NOT WIRED
+# Power Supply Failure, GP31(From W83627DHG-P)    1 = Good, 0 = Bad
+
+   ignore fan1
+   ignore fan2
+   ignore fan3
+   ignore fan4
+   ignore fan5
+   ignore temp1
+   ignore temp2
+   ignore temp3
+   ignore in0
+   ignore in1
+   ignore in2
+   ignore in3
+   ignore in4
+   ignore in5
+   ignore in6
+   ignore in7
+   ignore in8
+   ignore cpu0_vid

--- a/configs/SuperMicro/DLE370.conf
+++ b/configs/SuperMicro/DLE370.conf
@@ -1,0 +1,55 @@
+# lm_sensors 3 configuration file for the Supermicro DLE370 motherboard
+# 2007-09-26, Jean Delvare <khali@linux-fr.org>
+# Comments welcome!
+
+chip "lm87-*"
+
+### Voltages
+
+   label in1  "Vcore"
+   label in2  "+3.3V"
+   label in3    "+5V"
+   label in4   "+12V"
+
+   # All voltage inputs are scaled internally, so the driver itself
+   # takes care of it.
+
+   set in1_min  cpu0_vid - 0.08
+   set in1_max  cpu0_vid + 0.08
+   set in2_min   3.3 * 0.95
+   set in2_max   3.3 * 1.05
+   set in3_min     5 * 0.95
+   set in3_max     5 * 1.05
+   set in4_min    12 * 0.95
+   set in4_max    12 * 1.05
+
+### Fans
+
+   label fan1  "CPU0 Fan"
+   label fan2  "CPU1 Fan"
+
+   set fan1_div 4
+   set fan2_div 4
+
+   set fan1_min 1800
+   set fan2_min 1800
+
+   # Unfortunately, the analog output appears not to be wired to anything
+   # so there is no way to control the fan speeds.
+
+### Temperatures
+
+   label temp1   "Sys Temp"
+   label temp2  "CPU0 Temp"
+   label temp3  "CPU1 Temp"
+
+   # The BIOS will set the temperature limits to reasonable values, so
+   # you can leave them as is. I tend to prefer more restrictive settings
+   # though.
+
+   set temp1_min   5
+   set temp1_max  48
+   set temp2_min   5
+   set temp2_max  56
+   set temp3_min   5
+   set temp3_max  56

--- a/configs/SuperMicro/H8DC8.conf
+++ b/configs/SuperMicro/H8DC8.conf
@@ -1,0 +1,138 @@
+# Example configuration for the SuperMicro H8DC8.
+# Contributed by Romain Dolbeau.
+
+
+# settings for the supermicro H8DC8
+# here are the details supplied by the technical support:
+##Bus Type = SMBus
+##One WindBond W83627HF, One Analog Devices ADM1026
+##
+##Analog Devices ADM1026, Slave Address=0x2c (0x58 in 8-Bit format)
+##==============================================================
+##Fan1 Fan Speed, Offset 0x38           RPM=1350000/8/Reading
+##Fan2 Fan Speed, Offset 0x39           RPM=1350000/8/Reading
+##Fan3 Fan Speed, Offset 0x3a           RPM=1350000/8/Reading
+##Fan4 Fan Speed, Offset 0x3b           RPM=1350000/8/Reading
+##Fan5 Fan Speed, Offset 0x3c           RPM=1350000/8/Reading
+##Fan6 Fan Speed, Offset 0x3d           RPM=1350000/8/Reading
+##Fan7 Fan Speed, Offset 0x3e           RPM=1350000/8/Reading
+##Fan8 Fan Speed, Offset 0x3f           RPM=1350000/8/Reading
+##CPU1 Core Voltage, Offset 0x2d        Voltage=(Reading * 3)/256
+##CPU2 Core Voltage, Offset 0x37        Voltage=(Reading * 2.5)/256
+##+5VSB Voltage, offset 0x30            Voltage=(Reading * 6)/256
+##+1.5V Voltage, offset 0x32            Voltage=(Reading * 3)/256
+##+5V Voltage, offset 0x2c              Voltage=(Reading * 6.66)/256
+##+12V Voltage, offset 0x2e             Voltage=(Reading * 16)/256
+##-12V Voltage, offset 0x2f             Voltage=((Reading* 18.5)/256)-16
+##DIMM Voltage, offset 0x33             Voltage=(Reading * 3)/256
+##Battery Voltage, Offset 0x26
+##Voltage=(((Reading-128)*2)/128)+2)
+##System Temperature, Offset 0x1f       C=Reading
+##CPU1 Temperature, Offset 0x28         C=Reading
+##CPU2 Temperature, Offset 0x29         C=Reading
+##Chassis Intrusion, Offset 0x23, BitMask=40
+##
+##
+##Power Supply Failure (From W82627HF), GP12
+#
+# Notes:
+# 1) no section for the W82627HF yet.
+# 2) the temperature min/max are ballpark estimate,
+#    you may need to fix them depening on your environment
+#    such as the setting of your air conditionner.
+# 3) According to the support, in11 and in12 (both +3.3V
+#    lines) aren't hooked up, yet they supply proper readings
+#    (as specified by the manufacturer of the chip for those
+#    lines).
+#    You may want to disable them.
+#
+# Originally written by Romain Dolbeau <romain@dolbeau.org>
+# Uses at your own risk !
+
+chip "adm1026-i2c-*-2c"
+
+  label fan0 "FAN0 Speed"
+  label fan1 "FAN1 Speed"
+  label fan2 "FAN2 Speed"
+  label fan3 "FAN3 Speed"
+  label fan4 "FAN4 Speed"
+  label fan5 "FAN5 Speed"
+  label fan6 "FAN6 Speed"
+  label fan7 "FAN7 Speed"
+
+  set fan0_div 8
+  set fan1_div 8
+  set fan2_div 8
+  set fan3_div 8
+  set fan4_div 8
+  set fan5_div 8
+  set fan6_div 8
+  set fan7_div 8
+
+  label in0 "+5VSB Voltage"
+  compute in0 @*2,@/2
+  set in0_min 5*0.90
+  set in0_max 5*1.1
+
+  ignore in1
+
+  label in2 "+1.5V Voltage"
+  set in2_min 1.5*0.95
+  set in2_max 1.5*1.05
+
+  label in3 "DIMM Voltage"
+  set in3_min 2.5*0.95
+  set in3_max 2.5*1.05
+
+  ignore in4
+  ignore in5
+  ignore in6
+
+  label in7 "CPU2 Core Voltage"
+  set in7_min 1.35*0.95
+  set in7_max 1.35*1.05
+
+  ignore in8
+  ignore in9
+
+  label in10 "Battery Voltage"
+  set in10_min 3*0.95
+  set in10_max 3*1.05
+
+  # for in11 & in12, see comments above
+  #ignore in11
+  #ignore in12
+
+  label in11 "3.3V Standby"
+  set in11_min 3.3*0.95
+  set in11_max 3.3*1.05
+
+  label in12 "3.3V Main"
+  set in12_min 3.3*0.95
+  set in12_max 3.3*1.05
+
+  label in13 "+5V Voltage"
+  set in13_min 5*0.95
+  set in13_max 5*1.05
+
+  label in14 "CPU1 Core Voltage"
+  set in14_min 1.35*0.95
+  set in14_max 1.35*1.05
+
+  label in15 "+12V Voltage"
+  set in15_min 12*0.95
+  set in15_max 12*1.05
+
+  label in16 "-12V Voltage"
+  set in16_max -12*0.95
+  set in16_min -12*1.05
+
+  label temp1 "System Temperature"
+  set temp1_min 18
+  set temp1_max 40
+  label temp2 "CPU1 Temperature"
+  set temp2_min 20
+  set temp2_max 45
+  label temp3 "CPU2 Temperature"
+  set temp3_min 20
+  set temp3_max 45

--- a/configs/SuperMicro/H8QM3.conf
+++ b/configs/SuperMicro/H8QM3.conf
@@ -1,0 +1,30 @@
+# Sensors-detect will suggest loading the w83627hf driver, but don't, it's
+# useless on this board.
+
+
+chip "w83793-i2c-*-2f"
+
+   # Voltages
+   label  in0  "Vcore1"
+   label  in1  "Vcore2"
+   ignore in2
+   label  in3  "Vcore4"
+   label  in4  "Vcore3"
+   label  in5  "+3.3V"
+   label  in6  "+12V"
+
+   compute  in6  @*12, @/12
+
+   # Fans
+   label  fan3  "CPU2 Fan"
+   label  fan4  "CPU1 Fan"
+   label  fan7  "CPU4 Fan"
+   label  fan8  "CPU3 Fan"
+
+   # Temperatures
+   label  temp1  "CPU1 Temp"
+   label  temp2  "CPU2 Temp"
+   label  temp3  "CPU4 Temp"
+   label  temp4  "CPU3 Temp"
+   label  temp5  "Sys Temp"
+   # Not sure about temp6

--- a/configs/SuperMicro/PDSMi+.conf
+++ b/configs/SuperMicro/PDSMi+.conf
@@ -1,0 +1,82 @@
+# Example configuration for the SuperMicro PDSMi+.
+# Contributed by Romain Dolbeau & Jean Delvare
+
+
+# settings for the supermicro PDSMi+
+#
+# Notes:
+# 1) You need lm-sensors >= 2.10.2, otherwise you get an error about
+#    missing temp6.
+#
+# Originally written by Romain Dolbeau <romain@dolbeau.org>
+# Uses at your own risk !
+chip "w83793-i2c-*-2f"
+
+# 0x10, CPU Core
+    label in0 "CPU Core"
+# 0x11, unconnected according to support, 1.5V in BIOS ?
+    label in1 "+1.5V"
+    set in1_min 1.5*0.95
+    set in1_max 1.5*1.05
+# 0x12, unconnected according to support, VTT=1.2V in BIOS ?
+    label in2 "VTT"
+    set in2_min 1.2*0.95
+    set in2_max 1.2*1.05
+# 0x14, -12V
+    label in3 "-12V"
+#    From Supermicro support information...
+#    compute in3 (((@/8)*18500)/256)-16, (((@+16)*256)/18500)*8
+#    ... but this from Jean Delvare works better in pratice
+    compute in3 (@ * 5.14) - 14.91, (@ + 14.91) / 5.14
+    set in3_min -12*1.05
+    set in3_max -12*0.95
+# 0x15, DIMM
+    label in4 "DIMM"
+# 0x16, +3.3V
+    label in5 "+3.3V"
+    set in5_min 3.3*0.95
+    set in5_max 3.3*1.05
+# 0x17, +12V
+    label in6 "+12V"
+    compute in6 @*12,@/12
+    set in6_min 12*0.95
+    set in6_max 12*1.05
+# Ox18, +5V
+    label in7 "+5V"
+    compute in7 @-0.15,@+0.15
+    set in7_min 5*0.95
+    set in7_max 5*1.05
+# 0x19, 5VSB
+    label in8 "5VSB"
+    compute in8 @-0.15,@+0.15
+    set in8_min 5*0.95
+    set in8_max 5*1.05
+# 0x1a, Battery Voltage
+    label in9 "VBAT"
+
+    label temp1 "CPU Temp"
+    ignore temp2
+    ignore temp3
+    ignore temp4
+# System Temp used to live at temp5, but was moved to temp6 for some reason
+    ignore temp5
+#    label temp5 "System Temp"
+#    ignore temp6
+    label temp6 "System Temp"
+
+# 6 connected
+    label fan1 "fan1"
+    label fan2 "fan2"
+    label fan3 "fan3"
+    label fan4 "fan4"
+    label fan5 "fan5"
+# apparently, fan6 is skipped and fan7 is used instead for CPU fan,
+# at least that's how I understand Supermicro data.
+    ignore fan6
+    label fan7 "CPU fan"
+    ignore fan8
+    ignore fan9
+    ignore fan10
+    ignore fan12
+    ignore fan12
+# you should ignore the last 3 or 4, in 1U rackmount system

--- a/configs/SuperMicro/X6DH8-XG2.conf
+++ b/configs/SuperMicro/X6DH8-XG2.conf
@@ -1,0 +1,30 @@
+# Partial and untested configuration file for the SuperMicro X6DH8-XG2.
+# Please report if you try it.
+
+
+chip "pc87427-*"
+
+   label  fan7  "CPU1 Fan"
+   label  fan8  "CPU2 Fan"
+
+chip "lm93-*"
+
+   ignore fan1
+   ignore fan2
+   ignore fan3
+   ignore fan4
+
+   label  in1  "+12V"
+   label  in7  "VCore1"
+   label  in8  "VCore2"
+   label  in9  "+3.3V"
+   label  in10 "+5V"
+   ignore in11
+   label  in15 "-12V"
+
+   compute in1  @ * ((13.7/1.15)+1), @ / ((13.7/1.15)+1)
+   compute in15 @ * 5.1138 - 13.5771, (@ + 13.5771) / 5.1138
+
+   label  temp1  "CPU1 Temp"
+   label  temp2  "CPU2 Temp"
+   label  temp3  "Sys Temp"

--- a/configs/SuperMicro/X7DB8.conf
+++ b/configs/SuperMicro/X7DB8.conf
@@ -1,0 +1,121 @@
+# Originally contributed by Gary E. Miller, cleaned up by Jean Delvare.
+
+
+# /etc/sensors.d/X7DB8
+# settings for the supermicro X7DB8
+# originally written by Gary E. Miller <gem@rellim.com>
+# use at your own risk !
+# Date: 30 May 2012
+
+# Here's the info as supplied by Supermicro:
+#
+# Bus Type = SMBus
+# One W83793G
+# 
+# Windbond W83793G, Slave Address=0x2f (0x5E in 8-Bit format)
+# =============================================================
+# Fan1 Fan Speed, Offset 0x23, 0x24			RPM = 1350000/Data
+# Fan2 Fan Speed, Offset 0x25, 0x26			RPM = 1350000/Data
+# Fan3 Fan Speed, Offset 0x27, 0x28			RPM = 1350000/Data
+# Fan4 Fan Speed, Offset 0x29, 0x2a			RPM = 1350000/Data
+# Fan5 Fan Speed, Offset 0x2b, 0x2c			RPM = 1350000/Data
+# Fan6 Fan Speed, Offset 0x2d, 0x2e			RPM = 1350000/Data
+# Fan7/CPU1 Fan Speed, Offset 0x2f, 0x30		RPM = 1350000/Data
+# Fan8/CPU2 Fan Speed, Offset 0x31, 0x32		RPM = 1350000/Data
+# CPU1 Core Voltage, Offset 0x10			Voltage = Data* 0.008	
+# CPU2 Core Voltage, Offset 0x11			Voltage = Data* 0.008
+# -12V Voltage, Offset 0x14				Voltage = ((Data*0.016)- (2.048*(232./260.)))/(1-(232./260.))
+# +1.5V Voltage, Offset 0x15				Voltage = Data* 0.016
+# +3.3V Voltage, Offset 0x16				Voltage = Data* 0.016
+# +12V Voltage, Offset 0x17				Voltage = Data* 0.008/ (10./120.)
+# +5V Voltage, Offset 0x18				Voltage = Data* 0.024
+# 5Vsb Voltage, Offset 0x19				Voltage = Data* 0.024
+# Battery Voltage, Offset 0x1a				Voltage = Data* 0.016
+# CPU1 CoreA (PECI Agent1) Temperature, Offset 0x1c	Temperature = Data
+# CPU1 CoreB (PECI Agent2) Temperature, Offset 0x1d	Temperature = Data
+# CPU2 CoreA (PECI Agent3) Temperature, Offset 0x1e	Temperature = Data
+# CPU2 CoreB (PECI Agent4) Temperature, Offset 0x1f	Temperature = Data
+# System Temperature, Offset 0x20			Temperature = Data
+# Chassis Intrusion, Offset 0x44, BitMask 0x40		1 = Bad, 0 = Good
+# 
+# 
+# Windbond W83627HF
+# =============================================================
+# Power Supply Failure, GP11(From W83627HF)		1 = Good, 0 = Bad
+#
+
+chip "w83627hf-isa-0290"
+    # no driver access to GP11, so I turned off everything.
+    ignore in0
+    ignore in1
+    ignore in2
+    ignore in3
+    ignore in4
+    ignore in5
+    ignore in6
+    ignore in7
+    ignore in8
+    ignore cpu0_vid
+    ignore fan1
+    ignore fan2
+    ignore fan3
+    ignore temp1
+    ignore temp2
+    ignore temp3
+
+
+
+bus "i2c-0" "SMBus I801 adapter at 1100"
+
+chip "w83793-i2c-0-2f"
+
+	label fan7	"CPU1 Fan"
+	label fan8	"CPU2 Fan"
+
+# Voltages ; note that in the table above, the .008, .016, and .024 factors are
+# already computed in the driver...
+	label in0 "Vcore1"
+	label in1 "Vcore2"
+	ignore in2
+	label in3 "-12V"
+	label in4 "+1.5V"
+	label in5 "+3.3V"
+	label in6 "+12V"
+	label in7 "+5V"
+	label in8 "5Vsb"
+	label in9 "Vbat"
+
+	label temp1 "CPU1 CoreA"
+	label temp2 "CPU1 CoreB"
+	label temp3 "CPU2 CoreA"
+	label temp4 "CPU2 CoreB"
+	label temp5 "M/B Temp"
+
+	compute in3  (@ - (2.048*(232/260)))/(1-(232/260)), (@*(1-(232/260)))+(2.048*(232/260))
+	compute in6  @ * 12 , @ / 12
+
+
+	# CPUs
+	set in0_min  0.82
+	set in0_max  1.35
+	set in1_min  0.82
+	set in1_max  1.35
+
+	# -12V, 10%
+	set in3_max  -12.0 * 0.90
+	set in3_min  -12.0 * 1.10
+	# +3.3V, 5%
+	set in5_min  3.3 * 0.95
+	set in5_max  3.3 * 1.05
+	# +12V, 5%
+	set in6_min  12.0 * 0.95
+	set in6_max  12.0 * 1.05
+	# +5V, 5%
+	set in7_min  5.0 * 0.95
+	set in7_max  5.0 * 1.05
+	# 5Vsb, 10%
+	set in8_min  5.0 * 0.90
+	set in8_max  5.0 * 1.10
+	# Vbat, 10%
+	set in9_min  3.0 * 0.90
+	set in9_max  3.0 * 1.10

--- a/configs/SuperMicro/X7DBE.conf
+++ b/configs/SuperMicro/X7DBE.conf
@@ -1,0 +1,65 @@
+# settings for the SuperMicro X7DBE
+#
+# Notes:
+# 1) You need lm-sensors >= 2.10.2, otherwise you get an error about
+#    missing temp6.
+#
+# Originally written by Romain Dolbeau <romain@dolbeau.org>
+# Use at your own risk!
+
+chip "w83793-i2c-*-2f"
+
+# 0x10, CPU Core 1
+    label in0 "CPU Core 1"
+# 0x11, CPU Core 2
+    label in1 "CPU Core 2"
+# 0x12 VTT=1.2V in BIOS ?
+    label in2 "VTT"
+    set in2_min 1.2*0.95
+    set in2_max 1.2*1.05
+# 0x14, -12V
+    label in3 "-12V"
+    compute in3 (((@/8)*18500)/256)-16, (((@+16)*256)/18500)*8
+    set in3_min -12*1.05
+    set in3_max -12*0.95
+# 0x15, DIMM
+    label in4 "P1V5"
+# 0x16, +3.3V
+    label in5 "+3.3V"
+    set in5_min 3.3*0.95
+    set in5_max 3.3*1.05
+# 0x17, +12V
+    label in6 "+12V"
+    compute in6 @*12,@/12
+    set in6_min 12*0.95
+    set in6_max 12*1.05
+# Ox18, +5V
+    label in7 "+5V"
+    set in7_min 5*0.95
+    set in7_max 5*1.05
+# 0x19, 5VSB
+    label in8 "5VSB"
+    set in8_min 5*0.95
+    set in8_max 5*1.05
+# 0x1a, Battery Voltage
+    label in9 "VBAT"
+
+    label temp1 "CPU1 Temp"
+    label temp2 "CPU2 Temp"
+    ignore temp3
+    ignore temp4
+    label temp5 "System Temp"
+    ignore temp6
+
+    label fan1 "fan1"
+    label fan2 "fan2"
+    label fan3 "fan3"
+    label fan4 "fan4"
+    ignore fan5
+    ignore fan6
+    label fan7 "CPU1 fan"
+    label fan8 "CPU2 fan"
+    ignore fan9
+    ignore fan10
+    ignore fan11
+    ignore fan12

--- a/configs/SuperMicro/X7SBU.conf
+++ b/configs/SuperMicro/X7SBU.conf
@@ -1,0 +1,108 @@
+# Example configuration for the SuperMicro X7SBU. Contributed by Joe Ogulin.
+
+# Monitoring hardware on this board: Winbond W83793G on ICH9 SMBus (driver
+# w83793) and integrated sensors in the CPU (driver coretemp). A few voltages
+# also available from the Winbond W83627HF Super-I/O chip.
+
+
+# settings for the supermicro X7SBU
+#
+chip "w83793-*"
+
+# 0x10, CPU Core
+    label in0 "CPU Core"
+# 0x11, unconnected according to support, 1.5V in BIOS ?
+    label in1 "+1.25V"
+    set in1_min 1.25*0.95
+    set in1_max 1.25*1.05
+# 0x12, unconnected according to support, VTT=1.2V in BIOS ?
+    label in2 "VTT"
+# 0x14, -12V
+    label in3 "-12V"
+#    From Supermicro support information...
+#    compute in3 (((@/8)*18500)/256)-16, (((@+16)*256)/18500)*8
+#    ... but this from Jean Delvare works better in pratice
+    compute in3 (@ * 5.14) - 14.91, (@ + 14.91) / 5.14
+    set in3_min -12*1.05
+    set in3_max -12*0.95
+# 0x15, DIMM
+    label in4 "DIMM"
+# 0x16, +3.3V
+    label in5 "+3.3V"
+    set in5_min 3.3*0.95
+    set in5_max 3.3*1.05
+# 0x17, +12V
+    label in6 "+12V"
+    compute in6 @*12,@/12
+    set in6_min 12*0.95
+    set in6_max 12*1.05
+# Ox18, +5V
+    label in7 "+5V"
+    compute in7 @-0.15,@+0.15
+    set in7_min 5*0.95
+    set in7_max 5*1.05
+# 0x19, 5VSB
+    label in8 "5VSB"
+    compute in8 @-0.15,@+0.15
+    set in8_min 5*0.95
+    set in8_max 5*1.05
+# 0x1a, Battery Voltage
+    label in9 "VBAT"
+
+    label temp1 "CPU Temp"
+    ignore temp2
+    ignore temp3
+    ignore temp4
+    label temp5 "Sys Temp"
+    ignore temp6
+
+# 3 connected
+# note that these fan labels are for a 1U rackmount and are given their
+# positions based on where they are when you look at it from the front
+# towards the back
+#
+# relabel them as necessary to however you have them set up
+    label fan1 "Right Fan"
+    label fan2 "Mid-right Fan"
+    label fan3 "Middle Fan"
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore fan7
+    ignore fan8
+    ignore fan9
+    ignore fan10
+    ignore fan12
+    ignore fan12
+    # Override CPU temperature threshold
+    set temp1_max       80
+    set temp1_max_hyst  70
+
+    set temp5_max       60
+    set temp5_max_hyst  55
+
+# NOTE: nearly everything on this chip is not used you can turn on alarms, if
+# you have the appropriate setup for it and want to have chassis intrusion
+# detection turned on
+
+chip "w83627hf-*"
+
+    ignore in0
+    ignore in1
+    ignore in2
+    label in3 "+5.0V"
+    compute in3 ((6.8/10)+1)*@ ,  @/((6.8/10)+1)
+    set in3_min 5*0.95
+    set in3_max 5*1.05
+    ignore in4
+    ignore in5
+    ignore in6
+    ignore in7
+    ignore in8
+    ignore fan1
+    ignore fan2
+    ignore fan3
+    ignore alarms
+    ignore temp1
+    ignore temp2
+    ignore temp3

--- a/configs/SuperMicro/X7SBi.conf
+++ b/configs/SuperMicro/X7SBi.conf
@@ -1,0 +1,108 @@
+# Example configuration for the SuperMicro X7SBi. Contributed by Joe Ogulin.
+
+# Monitoring hardware on this board: Winbond W83793G on ICH9 SMBus (driver
+# w83793) and integrated sensors in the CPU (driver coretemp). A few voltages
+# also available from the Winbond W83627HF Super-I/O chip.
+
+
+# settings for the supermicro X7SBi
+#
+chip "w83793-*"
+
+# 0x10, CPU Core
+    label in0 "CPU Core"
+# 0x11, unconnected according to support, 1.5V in BIOS ?
+    label in1 "+1.5V"
+    set in1_min 1.5*0.95
+    set in1_max 1.5*1.05
+# 0x12, unconnected according to support, VTT=1.2V in BIOS ?
+    label in2 "VTT"
+    set in2_min 1.2*0.95
+    set in2_max 1.2*1.05
+# 0x14, -12V
+    label in3 "-12V"
+#    From Supermicro support information...
+#    compute in3 (((@/8)*18500)/256)-16, (((@+16)*256)/18500)*8
+#    ... but this from Jean Delvare works better in pratice
+    compute in3 (@ * 5.14) - 14.91, (@ + 14.91) / 5.14
+    set in3_min -12*1.05
+    set in3_max -12*0.95
+# 0x15, DIMM
+    label in4 "DIMM"
+# 0x16, +3.3V
+    label in5 "+3.3V"
+    set in5_min 3.3*0.95
+    set in5_max 3.3*1.05
+# 0x17, +12V
+    label in6 "+12V"
+    compute in6 @*12,@/12
+    set in6_min 12*0.95
+    set in6_max 12*1.05
+# Ox18, +5V
+    label in7 "+5V"
+    compute in7 @-0.15,@+0.15
+    set in7_min 5*0.95
+    set in7_max 5*1.05
+# 0x19, 5VSB
+    label in8 "5VSB"
+    compute in8 @-0.15,@+0.15
+    set in8_min 5*0.95
+    set in8_max 5*1.05
+# 0x1a, Battery Voltage
+    label in9 "VBAT"
+
+    label temp1 "CPU Temp"
+    ignore temp2
+    ignore temp3
+    ignore temp4
+    ignore temp5
+    label temp6 "Sys Temp"
+
+# 3 connected
+# note that these fan labels are for a 1U rackmount and are given their
+# positions based on where they are when you look at it from the front
+# towards the back
+#
+# relabel them as necessary to however you have them set up
+    label fan1 "Right Fan"
+    ignore fan2
+    ignore fan3
+    ignore fan4
+    label fan5 "Mid-right Fan"
+    ignore fan6
+    label fan7 "Middle Fan"
+    ignore fan8
+    ignore fan9
+    ignore fan10
+    ignore fan12
+    ignore fan12
+    # Override CPU temperature threshold
+    set temp1_max       80
+    set temp1_max_hyst  70
+
+    set temp6_max       60
+    set temp6_max_hyst  55
+
+# NOTE: nearly everything on this chip is not used you can turn on alarms, if
+# you have the appropriate setup for it and want to have chassis intrusion
+# detection turned on
+
+chip "w83627hf-*"
+
+    ignore in0
+    ignore in1
+    ignore in2
+    label in3 "+5.0V"
+    compute in3 ((6.8/10)+1)*@ ,  @/((6.8/10)+1)
+    ignore in4
+    ignore in5
+    ignore in6
+    ignore in7
+    ignore in8
+    ignore fan1
+    ignore fan2
+    ignore fan3
+    ignore alarms
+    ignore temp1
+    ignore temp2
+    ignore temp3

--- a/configs/SuperMicro/X7SLA.conf
+++ b/configs/SuperMicro/X7SLA.conf
@@ -1,0 +1,39 @@
+# Contributed by Jeff Rickman, fixes by Jean Delvare.
+
+
+chip "w83627dhg-*"
+
+    label in0 "Vcore"
+    label in1 "+12V"
+    label in2 "+3.3V"
+    label in3 "Vcc"
+    label in4 "Vdimm"
+    label in5 "+5V"
+    label in6 "+1.5V"
+    label in7 "3VSB"
+    label in8 "Vbat"
+
+    label fan1 "Back Fan"
+    label fan2 "P/S Fan"
+    label fan5 "Front Fan"
+    label fan4 "MCH Fan"
+
+    label temp1 "M/B Temp"
+    label temp2 "CPU Temp"
+
+    ignore fan3
+    ignore cpu0_vid
+    ignore temp3
+
+    # Scaling factor for +12V needs confirmation
+    compute in1  @*6.63, @/6.63
+    compute in5  @*4, @/4
+
+    set in2_min  3.3 * 0.90
+    set in2_max  3.3 * 1.10
+    set in3_min  3.3 * 0.90
+    set in3_max  3.3 * 1.10
+    set in7_min  3.3 * 0.90
+    set in7_max  3.3 * 1.10
+    set in8_min  3.0 * 0.90
+    set in8_max  3.0 * 1.10

--- a/configs/SuperMicro/X7SPA.conf
+++ b/configs/SuperMicro/X7SPA.conf
@@ -1,0 +1,32 @@
+# Configuration file contributed by Scott Shanafelt.
+
+
+chip "w83627dhg-*"
+
+	label in0 "Vcore"
+	label in1 "+1.05V"
+	label in2 "AVCC"
+	label in3 "3VCC"
+		set in3_min 3.3 * 0.90
+		set in3_max 3.3 * 1.10
+	label in4 "Vdimm"
+	label in5 "+5V"
+		compute in5 @*4, @/4
+	label in6 "+12V"
+		compute in6 @*16, @/16
+		set in6_min 12 * 0.90
+		set in6_max 12 * 1.10
+	label in7 "3VSB"
+	label in8 "Vbat"
+
+	ignore fan1
+	label fan2 "CPU Fan"
+	ignore fan3
+	label fan4 "Case Fan"
+	ignore fan5
+
+	label temp1 "MB Temp"
+	label temp2 "CPU Temp"
+	label temp3 "Case Temp"
+
+	ignore cpu0_vid

--- a/configs/SuperMicro/X8DTN.conf
+++ b/configs/SuperMicro/X8DTN.conf
@@ -1,0 +1,100 @@
+# /etc/sensors.d/X8DTN
+# settings for the supermicro X8DTN
+# originally written by Gary E. Miller <gem@rellim.com>
+# use at your own risk !
+# Date: 25 May 2012
+
+# Here's the info as supplied by Supermicro:
+
+#
+# Bus Type = ISAIO/SMBus
+# One W83795AG
+# 
+# Windbond W83795AG, Slave Address=0x2f (0x5E in 8-Bit format)
+# =============================================================
+# Fan1 Fan Speed, Offset 0x2e		RPM = 84375/Data
+# Fan2 Fan Speed, Offset 0x2f		RPM = 84375/Data
+# Fan3 Fan Speed, Offset 0x30		RPM = 84375/Data
+# Fan4 Fan Speed, Offset 0x31		RPM = 84375/Data
+# Fan5 Fan Speed, Offset 0x32		RPM = 84375/Data
+# Fan6 Fan Speed, Offset 0x33		RPM = 84375/Data
+# Fan7 Fan Speed, Offset 0x34		RPM = 84375/Data
+# Fan8 Fan Speed, Offset 0x35		RPM = 84375/Data
+# CPU1 Voltage, Offset 0x10		Voltage = Data* 0.008
+# CPU2 Voltage, Offset 0x11		Voltage = Data* 0.008
+# +1.5V Voltage, Offset 0x12		Voltage = Data* 0.008
+# +5V Voltage, Offset 0x13		Voltage = Data* 0.008 * (40/10)
+# +12V Voltage, Offset 0x14		Voltage = Data* 0.008/ (10./66.2)
+# +5VSB Voltage, Offset 0x15		Voltage = Data* 0.008 * (40/10)
+# +3.3V Voltage, Offset 0x1c		Voltage = Data* 0.024
+# +3.3VSB Voltage, Offset 0x1d		Voltage = Data* 0.024
+# Battery Voltage, Offset 0x1e		Voltage = Data* 0.024
+# CPU1 Temperature, Offset 0x27		Temperature = Data
+# CPU2 Temperature, Offset 0x26		Temperature = Data
+# System Temperature, Offset 0x1f		Temperature = Data
+# Chassis Intrusion, Bank 0, Offset 0x46, BitMask 0x40	1 = Bad, 0 = Good
+#		 (Clear Bit: Bank 0, Offset 0x4d, BitMask 0x80)
+# 
+# 
+# Power Supply Failure, GP11(From W83627HF)		1 = Good, 0 = Bad
+ 
+chip "w83627hf-isa-0a00"
+    # I'm not sure which is GP11, so I turned off everything.
+    ignore in0
+    ignore in1
+    ignore in2
+    ignore in3
+    ignore in4
+    ignore in5
+    ignore in6
+    ignore in7
+    ignore in8
+    ignore cpu0_vid
+    ignore fan1
+    ignore fan2
+    ignore fan3
+    ignore temp1
+    ignore temp2
+    ignore temp3
+ 
+bus "i2c-0" "SMBus I801 adapter at 0400"
+
+chip "w83795adg-i2c-0-2f"
+
+# Voltages ; note that in the table above, the .008 and .024 factors are
+# already computed in the driver...
+
+    label in0 "CPU1"
+    label in1 "CPU2"
+    label in2 "+1.5V"
+    label in3 "+5V"
+    label in4 "+12V"
+    label in5 "5VSB"
+    label in12 "+3.3V"
+    label in13 "3VSB"
+    label in14 "Vbat"
+
+    compute in3 @*4, @/4
+    compute in4 @*6.62, @/6.62
+    compute in5 @*4, @/4
+
+    label temp5 "mobo"
+    label temp7 "CPU2"
+    label temp8 "CPU1"
+
+    ignore in6
+    ignore in7
+    ignore in11
+    ignore temp3
+    ignore temp4
+
+    set in0_min  0.82
+    set in0_max  1.35
+    set in1_min  0.82
+    set in1_max  1.35
+    set in12_min  3.3 * 0.90
+    set in12_max  3.3 * 1.05
+    set in13_min  3.3 * 0.95
+    set in13_max  3.3 * 1.10
+    set in14_min  3.0 * 0.90
+    set in14_max  3.3 * 1.10

--- a/configs/SuperMicro/X9SRA.conf
+++ b/configs/SuperMicro/X9SRA.conf
@@ -1,0 +1,56 @@
+# Configuration file contributed by Eric Wedel.
+
+
+# Supermicro X9SRA motherboard lm-sensors configuration.
+# Voltage inputs & scaling per Supermicro support.  Other
+# inputs from BIOS screen and observation.
+
+chip "nct6776-*"
+
+### Voltages
+
+label in0 "Vcore"
+
+label in1 "+12V"
+compute in1 @ * (66.2/10), @ / (66.2/10)
+
+label in2 "AVcc"
+
+label in3 "+3.3V"
+
+label in4 "Vdimm"
+
+label in5 "+5V"
+compute in5 @ * 4, @ / 4
+
+label in6 "Vtt"
+
+label in7 "+3.3Vsb"
+
+label in8 "Vbatt"
+
+### Temperatures
+
+# not sure about temp1 / temp2 assignments
+
+label temp1 "System temperature"
+label temp2 "Peripheral temperature"
+
+ignore temp3
+
+# PECI agent 0:
+label temp7 "CPU temperature"
+
+label temp8 "PCH temperature"
+
+ignore temp9
+ignore temp10
+
+## fans: gratuitous renumbering between Supermicro & lm-sensors.
+## Use display labels which match X9SRA fan connector labels.
+
+label fan1  "fanA"
+label fan2  "fan1"
+label fan3  "CPU Fan"
+label fan4  "fan3"
+label fan5  "Exhaust Fan"

--- a/configs/Tyan/S2466-4M.conf
+++ b/configs/Tyan/S2466-4M.conf
@@ -1,0 +1,109 @@
+#    Sensors configuration file used by 'libsensors' for Tyan S2466-4M
+#
+# Edited by: kevin schlichter <kevins at tyan dot com> 05.16.03
+# Update 07.30.03:kevin schlichter: add vid support
+# Update 2009-Apr-01 Adam Thompson <athompso at athompso dot net>: radically 
+#   updated for lm_sensors 3.0.2 & Linux kernel 2.6.27 (aka Ubuntu 8.10)
+#
+# Note that in the 2.6 series of kernels, with lm_sensors 3.0.2, it is
+# no longer necessary to jump through force_subclient= and ignore_* hoops
+# when loading the w83782d module; its default behaviour is sufficient
+# to support itself correctly (and it finds the 3 subclients without any
+# additional prompting).  This does NOT allow access to the other chip,
+# a W83627HF, over I2C, but this second chip is mapped into the ISA I/O 
+# space anyway, and loading the "w83627hf" module without any options 
+# locates it and accesses it perfectly fine.  See also notes below about
+# the inadvisability of overusing the I2C bus on this motherboard anyway.
+# This has only been tested on MY board, which is the -4M variant, with
+# BIOS 4.06.  Depending on your BIOS version, you may or may not want to 
+# use the "init=0" module options INSTEAD OF setting various mins & maxes 
+# below, particularly temperature-wise.  YMMV.
+# -Adam Thompson, 2009-Apr-01
+#####
+
+# set min/max limits to  5% for the critical voltages
+# set min/max limits to 10% for the non-critical voltages
+# set min/max limits to 20% for the battery voltage
+
+
+chip "w83782d-*"
+    ignore  in0 
+    ignore  in1
+    label   in2 "AGP V"
+    set     in2_min 3.3*0.95
+    set     in2_max 3.3*1.05
+    label   in3 " +5 V"
+    compute in3 ((6.8/10)+1)*@ ,  @/((6.8/10)+1)
+    set     in3_min 5.0*0.95
+    set     in3_max 5.0*1.05
+    label   in4 "DDR V"
+    ignore  in5
+    ignore  in7
+    label   in6 "3 VSB"
+    set     in6_max 3.0*1.05
+    set     in6_min 3.0*0.95
+    label   in8 "Bat V"
+    set     in8_min 3.3*0.80
+    set     in8_max 3.3*1.20
+    ignore  vid
+    label   fan1 "Chassis Fan 2"
+    label   fan2 "Chassis Fan 1"
+    label   fan3 "PSU Fan"
+    label   temp1 "VRM2 Temp"
+    label   temp2 "CPU1 Temp"
+    label   temp3 "CPU2 Temp"
+#    set     temp1_type 2
+#    set     temp1_max 40	
+#    set     temp1_max_hyst 60	
+#    set     temp2_type 2
+#    set     temp2_max 70	
+#    set     temp2_max_hyst 80	
+#    set     temp3_type 2
+#    set     temp3_max 70	
+#    set     temp3_max_hyst 80	
+
+# lm_sensors ticket#1795 (http://www.lm-sensors.org/ticket/1795) also 
+# strongly suggests using the ISA bus where possible to avoid overloading
+# the SMBus on Tyan motherboards.
+# Accessing this via ISA inb/outb also avoids the need altogether to use
+# force_subclient= options when loading the w83782d module.
+
+chip "w83627hf-*"
+    label   in0 "VCore1"
+    set     in0_min cpu0_vid*0.95
+    set     in0_max cpu0_vid*1.05
+    label   in1 "VCore2"
+    set     in1_min cpu0_vid*0.95
+    set     in1_max cpu0_vid*1.05
+    label   in2 "+3.3 V"
+    set     in2_min 3.3*0.95
+    set     in2_max 3.3*1.05
+    ignore  in3
+    label   in4 " +12 V"
+    compute in4 ((3.8/1)+1)*@ , @/((3.8/1)+1)
+    set     in4_max 12*0.90
+    set     in4_min 12*1.10
+    label   in5 " -12 V"
+    compute in5 (5.14*@)-14.91 , (@+14.91)/5.14
+    set     in5_max -12*0.90
+    set     in5_min -12*1.10
+    ignore  in6
+    ignore  in7
+    ignore  in8
+    ignore  vid
+    label   temp1 "VRM1 Temp"
+    label   temp2 "AGP Temp"
+    label   temp3 "DDR Temp"
+    label   fan1 "CPU1 Fan"
+    label   fan2 "CPU2 Fan"
+    ignore  fan3 
+#    set     temp1_type 2
+#    set     temp1_max 40
+#    set     temp1_max_hyst 37
+#    set     temp2_type 2
+#    set     temp2_max 52
+#    set     temp2_max_hyst 47
+#    set     temp3_type 2
+#    set     temp3_max 52
+#    set     temp3_max_hyst 47
+    set     beep_enable 0

--- a/configs/VIA/EPIA-M920.conf
+++ b/configs/VIA/EPIA-M920.conf
@@ -1,0 +1,30 @@
+# Configuration file reportedly provided to users by VIA themselves.
+
+
+chip "f71869-*"
+
+    label in0 "+3.3V"
+    label in1 "+Vcore"
+    label in4 "Vdimm"
+    label in3 "+3.3V"
+    label in2 "+5V"
+    label in6 "+12V"
+    label in7 "3VSB"
+    label in8 "Vbat"
+    label fan1 "CPU Fan Speed"
+    label fan2 "System Fan Speed"
+    label temp1 "CPU Temperature"
+    label temp2 "System Temperature"
+
+    compute in0  @*2    , @/2
+    compute in2  @*2.5  , @/2.5
+    compute in3  @*2    , @/2
+    compute in4  @*1.47 , @/1.47
+    compute in6  @*11   , @/11
+    compute in7  @*2    , @/2
+    compute in8  @*2    , @/2
+
+    ignore in5
+    ignore fan3
+    ignore fan4
+    ignore temp3

--- a/configs/Zotac/H55-ITX.conf
+++ b/configs/Zotac/H55-ITX.conf
@@ -1,0 +1,48 @@
+# Configuration contributed by Jean Delvare.
+
+
+chip "w83667hg-isa-0a10"
+
+   # Voltages
+
+   label  in0 "Vcore"
+   label  in1 "Vtt"
+   label  in2 "AVCC"
+   label  in3 "+3.3V"
+   label  in4 "PCH"
+   label  in5 "IGD"
+   label  in7 "3VSB"
+   label  in8 "Vbat"
+
+   set in1_min  1.1 * 0.95
+   set in1_max  1.1 * 1.05
+   set in2_min  3.3 * 0.90
+   set in2_max  3.3 * 1.10
+   set in3_min  3.3 * 0.90
+   set in3_max  3.3 * 1.10
+   set in4_min  1.1 * 0.95
+   set in4_max  1.1 * 1.05
+   set in7_min  3.3 * 0.90
+   set in7_max  3.3 * 1.10
+   set in8_min  3.0 * 0.90
+   set in8_max  3.0 * 1.10
+
+   # Fans
+
+   # I don't know which fan headers exist and which don't.
+   #ignore fan1
+   label  fan2 "CPU Fan"
+   #ignore fan3
+   #ignore fan4
+   #ignore fan5
+
+   set fan2_min  800
+
+   # Temperatures
+
+   label  temp1 "M/B Temp"
+   label  temp2 "CPU Temp"
+   ignore temp3
+
+   set temp1_max       55
+   set temp1_max_hyst  52

--- a/configs/Zotac/ZBox-HD-ID11.conf
+++ b/configs/Zotac/ZBox-HD-ID11.conf
@@ -1,0 +1,59 @@
+# Contributed by Piotr Maksymiuk.
+
+
+##/etc/sensors.d/zbox-hd-id-11
+
+chip "w83667hg-isa-0a10"
+
+   # Voltages
+
+   label  in0 "Vcore"
+   label  in1 "RAM"
+   label  in2 "AVCC"
+   label  in3 "+3.3V"
+   label  in4 "Chipset"
+   label  in5 "+1.5V"
+   label  in6 "3VSB"
+
+   set in0_min  1.1 * 0.90
+   set in0_max  1.1 * 1.10
+   set in1_min  1.9 * 0.90
+   set in1_max  1.9 * 1.10
+   set in2_min  3.3 * 0.90
+   set in2_max  3.3 * 1.10
+   set in3_min  3.3 * 0.90
+   set in3_max  3.3 * 1.10
+   set in4_min  1.1 * 0.90
+   set in4_max  1.1 * 1.10
+   set in5_min  1.5 * 0.90
+   set in5_max  1.5 * 1.10
+
+   # Fans
+
+   # Only fan2 is used in this barebone.
+   ignore fan1
+   label  fan2 "Case Fan"
+   ignore fan3
+   ignore fan4
+   ignore fan5
+
+   set fan2_min  800
+
+   # Temperatures
+
+   #unfortunately i'm not sure if temp3 is ram
+   label  temp1 "M/B Temp"
+   label  temp2 "CPU Temp"
+   label  temp3 "RAM Temp"
+
+   #this always returns a 0 reading
+   ignore cpu0_vid
+
+   set temp1_max       50
+   set temp1_max_hyst  40
+
+   set temp2_max       75
+   set temp2_max_hyst  60
+
+   set temp3_max       35
+   set temp3_max_hyst  30


### PR DESCRIPTION
This is a bulk recovery of the sensor configs found at https://web.archive.org/web/20150901092438/http://www.lm-sensors.org:80/wiki/Configurations

The config sections themselves are unaltered, but I've selectively added some, but not all of the extra info around them. Anywhere there's been extra info added, it should be in comments at the top of the config, followed by a double newline to indicate the separation. Attribution has been retained where possible, but links to the mailing list are hosed, so goto the above archive.org link to check if a config has extra origin notes.