### PR TITLE
Add hardwired Nuvoton NCT6795D inputs

### DIFF
--- a/etc/sensors.conf.default
+++ b/etc/sensors.conf.default
@@ -311,7 +311,7 @@ chip "w83627thf-*"
 #    set in8_max  3.0 * 1.10
 
 
-chip "w83627ehf-*" "w83627dhg-*" "w83667hg-*" "nct6775-*" "nct6776-*" "nct6779-*" "nct6791-*"
+chip "w83627ehf-*" "w83627dhg-*" "w83667hg-*" "nct6775-*" "nct6776-*" "nct6779-*" "nct6791-*" "nct6795-*"
 
     label in0 "Vcore"
     label in2 "AVCC"


### PR DESCRIPTION
It looks like Nuvoton NCT6795D has the same hardwired inputs as other
members of its family, so let's add it to the appropriate section of
sensors.conf.default.

This was determined experimentally on a MSI MS-7A34 (B350 TOMAHAWK) board.
