### PR TITLE
Update vt1211_pwm

### DIFF
--- a/prog/pwm/vt1211_pwm
+++ b/prog/pwm/vt1211_pwm
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # vt1211_pwm - Manually control the PWM outputs of the VIA vt1211 Super-I/O
 #


### PR DESCRIPTION
the script uses bashisms that work only if sh is bash. if not this will fail. Consequently shebang should be bash, not sh.