### PR TITLE
Update H170+D3.conf

### DIFF
--- a/configs/Gigabyte/H170+D3.conf
+++ b/configs/Gigabyte/H170+D3.conf
@@ -1,7 +1,12 @@
 # Gigabyte H170+D3 Motherboard, see $(dmidecode -s baseboard-product-name)
-# dmi: H170-PLUS D3
-# 2018, by J. Schwender
+# 2018, contributed by J. Schwender
+# dmi: board_name: H170-PLUS D3
+# dmi: board_vendor: ASUSTeK COMPUTER INC.
+# dmi: board_version: Rev X.0x
+# dmi: bios_version: 0403
 # driver: nct6775
+# cpu: intel core i5, you may have to adjust voltage limits for other processors
+# no chassis fan installed, you may adjust fan labels accordingly
 #
 chip "nct6793-isa-*"
 	ignore fan1


### PR DESCRIPTION
Changes refer to issue #88. This change is backward compatible and is only a suggestion, a reference how the dmi and other information could be simply added into the config file for a board.