### PR TITLE
ASRock AB350 Pro4, HP MicroServer N40L and Asus P8B75-V configs

### DIFF
--- a/configs/ASRock/AB350_Pro4.conf
+++ b/configs/ASRock/AB350_Pro4.conf
@@ -1,0 +1,93 @@
+# ASRock AB350 Pro4
+# 2018, contributed by Leigh Brown
+#
+# dmi: board_name:   AB350 Pro4
+# dmi: board_vendor: ASRock
+# dmi: bios_version: P4.60
+# cpu: AMD Ryzen 5 1600 Six-Core Processor
+# driver: nct6775
+
+chip "k10temp-pci-00c3"
+    label temp1 "CPU Core Temp"
+
+chip "nct6779-isa-0290"
+    label   in0     "Vcore"
+    compute in0     @*2, @/2
+    set     in0_min 0.30
+    set     in0_max 1.45
+
+    label   in1     "+5.0V"
+    compute in1     @*4, @/4
+    set     in1_min 5.00 * 0.90
+    set     in1_max 5.00 * 1.10
+
+    label   in2     "AVCC"
+    set     in2_min 3.30 * 0.90
+    set     in2_max 3.30 * 1.10
+
+    label   in3     "+3.3V"
+    set     in3_min 3.30 * 0.90
+    set     in3_max 3.30 * 1.10
+
+    label   in4     "+12.0V"
+    compute in4     @*(66/10), @/(66/10)
+    set     in4_min 12.0 * 0.95
+    set     in4_max 12.0 * 1.05
+
+    label   in5      "VDDCR_SOC"
+    set     in5_min  0.80
+    set     in5_max  1.20
+
+    label   in6     "DRAMV"
+    set     in6_min 1.10 # DDR4 Underclocking
+    set     in6_max 1.50 # DDR4 Intel XMP2.0 recommended max safe voltage
+
+    label   in7     "3VSB"
+    set     in7_min 3.30 * 0.90
+    set     in7_max 3.30 * 1.10
+
+    label   in8 "VBAT"
+    set     in8_min 3.00 * 0.90
+    set     in8_max 3.30 * 1.10
+
+    ignore in9
+
+    label   in10     "VDDP"
+    set     in10_min 0.90
+    set     in10_max 1.20
+
+    label   in11     "+1.05V"
+    set     in11_min 1.05 * 0.9
+    set     in11_max 1.05 * 1.1
+
+    ignore in12
+    ignore in13
+
+    label   in14     "+1.8V"
+    set     in14_min 1.8 * 0.9
+    set     in14_max 1.8 * 1.1
+
+    label  fan1     "Chassis Fan 3"
+    label  fan2     "CPU Fan 1"
+    set    fan2_min 400
+    ignore fan3
+    label  fan4     "Chassis Fan 1"
+    label  fan5     "Chassis Fan 2"
+
+    label  temp1   "Motherboard Temp"
+    set temp1_max      55.0
+    set temp1_max_hyst 50.0
+
+    label  temp2   "CPU Temp"
+
+    ignore temp3
+    ignore temp4
+    ignore temp5
+    ignore temp6
+    ignore temp7
+    ignore temp8
+    ignore temp9
+    ignore temp10
+
+    ignore intrusion0
+    ignore intrusion1

--- a/configs/Asus/P8B75-V.conf
+++ b/configs/Asus/P8B75-V.conf
@@ -1,0 +1,72 @@
+# ASUSTeK COMPUTER INC. P8B75-V Motherboard
+# 2018, contributed by Leigh Brown
+#
+# dmi: board_name:   P8B75-V
+# dmi: board_vendor: ASUSTeK COMPUTER INC.
+# dmi: bios_version: 1608
+# cpu: Intel(R) Core(TM) i3-3220 CPU @ 3.30GHz
+# driver: nct6775
+#
+# NB: temp7 (PECI Agent 0) is very inaccurate at low temperatures
+# NB: Vcore limits may be different for different CPUs
+
+chip "nct6779-isa-*"
+    label   in0     "Vcore"
+    set     in0_min 0.44	# Will reduce when idle
+    set     in0_max 1.08 * 1.10	# Allow for a small amount of overclocking
+
+    label   in1     "+5V"
+    compute in1     @*5, @/5
+    set     in1_min 5.00 * 0.90
+    set     in1_max 5.00 * 1.10
+
+    label   in2 "AVCC"
+    set     in2_min 3.30 * 0.90
+    set     in2_max 3.30 * 1.10
+
+    label   in3     "+3.3V"
+    set     in3_min 3.30 * 0.90
+    set     in3_max 3.30 * 1.10
+
+    label   in4     "+12V"
+    compute in4     @*12, @/12
+    set     in4_min 12.0 * 0.95
+    set     in4_max 12.0 * 1.05
+
+    label   in7     "3VSB"
+    set     in7_min 3.30 * 0.90
+    set     in7_max 3.30 * 1.10
+
+    label   in8     "VBAT"
+    set     in8_min 3.00 * 0.90
+    set     in8_max 3.30 * 1.10
+
+    ignore in5
+    ignore in6
+    ignore in9
+    ignore in10
+    ignore in11
+    ignore in12
+    ignore in13
+    ignore in14
+
+    # Fans
+    label  fan1 "CHA_FAN1"
+    label  fan2 "CPU_FAN1"
+    ignore fan3
+    label  fan4 "CHA_FAN2"
+    ignore fan5
+
+    set temp1_max      40.0
+    set temp1_max_hyst 35.0
+
+    ignore temp3
+    ignore temp4
+    ignore temp5
+    ignore temp6
+    ignore temp8
+    ignore temp9
+    ignore temp10
+
+    ignore intrusion0
+    ignore intrusion1

--- a/configs/HP/MicroServer_N40L.conf
+++ b/configs/HP/MicroServer_N40L.conf
@@ -1,0 +1,46 @@
+# HP MicroServer N40L
+# 2018, contributed by Leigh Brown
+#
+# dmi: sys_vendor:   HP
+# dmi: product_name: ProLiant MicroServer
+# dmi: bios_version: O41
+# cpu: AMD Turion(tm) II Neo N40L Dual-Core Processor
+# module: w83795adg
+#
+# This configuration will probably also work with the N54L version
+
+bus "i2c-0" "SMBus PIIX4 adapter port 0 at 0b00"
+bus "i2c-1" "SMBus PIIX4 adapter port 2 at 0b00"
+
+chip "jc42-i2c-0-18"
+    label temp1           "DIMM A Temp"
+    set   temp1_max       60
+    set   temp1_crit      70
+    set   temp1_crit_hyst 65
+
+chip "jc42-i2c-0-19"
+    label temp1           "DIMM B Temp"
+    set   temp1_max       60
+    set   temp1_crit      70
+    set   temp1_crit_hyst 65
+
+chip "k10temp-pci-*"
+    label temp1           "CPU Core Temp"
+
+chip "w83795adg-i2c-1-2f"
+    label  in0     "VSEN1"
+    set    in0_min 0.50
+    set    in0_max 1.20
+
+    label  in1     "VSEN2"
+    set    in1_min 1.424
+    set    in1_max 1.574
+
+    label  in2     "VSEN3"
+    ignore in3
+
+    label  fan1    "System Fan"
+
+    label temp1    "CPU Temp"
+    label temp2    "Northbridge Temp"
+    label temp5    "System Temp"


### PR DESCRIPTION
New configs for the following:
1. ASRock AB350 Pro4 Motherboard
2. HP MicroServer N40L System
3. Asus P8B75-V Motherboard
