### PR TITLE
Add detection of AMD Ryzen w/ Vega graphics

### DIFF
--- a/prog/detect/sensors-detect
+++ b/prog/detect/sensors-detect
@@ -2773,7 +2773,7 @@ use vars qw(@cpu_ids);
 	}, {
 		name => "AMD Family 17h thermal sensors",
 		driver => "k10temp",
-		detect => sub { amd_pci_detect('1463') },
+		detect => sub { amd_pci_detect('1463', '15d0') },
 	}, {
 		name => "AMD Family 15h power sensors",
 		driver => "fam15h_power",


### PR DESCRIPTION
Kernel support was added in commit
https://github.com/torvalds/linux/commit/877d8948d0aa402fb