### PR TITLE
Adding documentation of the chip_name to bus_id relationship.

### DIFF
--- a/lib/libsensors.3
+++ b/lib/libsensors.3
@@ -212,6 +212,18 @@ the program). Never let it return!
 
 .SH DATA STRUCTURES
 
+Structure \fBsensors_chip_name\fR contains information related to a
+specific chip.
+
+\fBtypedef struct sensors_chip_name {
+.br
+	sensors_bus_id bus;
+.br
+} sensors_chip_name;\fP
+
+There are other members not documented here, which are only meant for
+libsensors internal use.
+
 Structure \fBsensors_feature\fR contains information related to a given
 feature of a specific chip:
 


### PR DESCRIPTION
Minor addition to the documentation to show the bus member of sensors_chip_name.  This becomes important when calling sensors_get_adapter_name(), which requires knowledge of this relationship.

Thanks!
-Elliott