### PR TITLE
update GA-AX370-GAMING5.conf to remove fan minimums

### DIFF
--- a/configs/Gigabyte/GA-AX370-GAMING5.conf
+++ b/configs/Gigabyte/GA-AX370-GAMING5.conf
@@ -30,10 +30,6 @@ chip "it8792-isa-*"
 	label fan2 "SYS6 fan/pump"
 	label fan3 "SYS4 fan"
 
-	set fan1_min 300
-	set fan2_min 300
-	set fan3_min 300
-
 	ignore in0
 	ignore in3
 	ignore in6
@@ -81,12 +77,6 @@ chip "it8686-isa-*"
 	label fan3 "SYS2 fan"
 	label fan4 "SYS3 fan"
 	label fan5 "CPUOPT fan"
-
-	set fan1_min 300
-	set fan2_min 300
-	set fan3_min 300
-	set fan4_min 300
-	set fan5_min 300
 
 	ignore in7
 	ignore in8


### PR DESCRIPTION
Removed fan minimums from configuration since any unused fan headers register as 0 RPM causing a continuous alarm from the board buzzer/speaker when using this conf file. The GA-AX370-GAMING5 allows for setting fail warnings for specific system fans using Smart Fan 5 in the UEFI/BIOS settings anyway, which all default to off.