### PR TITLE
configs: Add Gigabyte GA-AX370M-DS3H Motherboard

### DIFF
--- a/configs/Gigabyte/GA-AX370-DS3H.conf
+++ b/configs/Gigabyte/GA-AX370-DS3H.conf
@@ -1,0 +1,39 @@
+# Configuration file for the Gigabyte GA-AX370M-DS3H.
+
+# The temp3 temperature offset depends on the CPU type and needs to be
+# adjusted. Compare against the output of k10temp for the correct value.
+
+chip "it8686-isa-0a40"
+	label temp1 "System 1"
+	label temp2 "Chipset"
+	label temp3 "CPU Socket"
+	label temp4 "PCI-EX16" # not sure
+	label temp5 "VRM MOS"  # not sure
+	label temp6 "vSOC MOS" # not sure
+
+	label in0 "CPU Vcore"
+	label in1 "+3.3v"
+	label in2 "+12v"
+	label in3 "+5v"
+	label in4 "CPU Vcore SOC"
+	label in5 "CPU Vddp"
+	label in6 "DRAM A/B"
+	label in7 "3VSB"
+	label in8 "Battery"
+
+	label fan1 "CPU_FAN"
+	label fan2 "SYS_FAN1"
+
+	compute temp3 @+2,@+2
+	compute in1 @*1.65,@*1.65
+	compute in2 @*6,@*6
+	compute in3 @*2.5,@*2.5
+
+	set in0_min 0.35
+	set in0_max 1.45
+	set in2_min 1.97
+	set in2_max 2.05
+	set in6_min 1.2 * 0.97
+	set in6_max 1.2 * 1.2
+	set in7_min 3.3 * 0.97
+	set in7_max 3.3 * 1.05

--- a/configs/Gigabyte/GA-AX370M-DS3H.conf
+++ b/configs/Gigabyte/GA-AX370M-DS3H.conf
@@ -25,15 +25,23 @@ chip "it8686-isa-0a40"
 	label fan2 "SYS_FAN1"
 
 	compute temp3 @+2,@+2
-	compute in1 @*1.65,@*1.65
-	compute in2 @*6,@*6
-	compute in3 @*2.5,@*2.5
+	compute in1 @ * (33/20), @ / (33/20)
+	compute in2 @ * (120/20), @ / (120/20)
+	compute in3 @ * (50/20), @ / (50/20)
 
-	set in0_min 0.35
+	set in0_min 0.20
 	set in0_max 1.45
-	set in2_min 1.97
-	set in2_max 2.05
-	set in6_min 1.2 * 0.97
-	set in6_max 1.2 * 1.2
+
+	set in1_min 3.3 * 0.97
+	set in1_max 3.3 * 1.03 
+	set in2_min 12 * 0.97
+	set in2_max 12 * 1.03
+	set in3_min 5 * 0.97
+	set in3_max 5 * 1.03
+
+	set in4_min 1.00
+	set in4_max 1.35
+	set in6_min 1.15
+	set in6_max 1.5
 	set in7_min 3.3 * 0.97
 	set in7_max 3.3 * 1.05


### PR DESCRIPTION
This board is very similar to the GA-AB350-GAMING3 board.
The config was only tested on a board with an it8686 chip.